### PR TITLE
Add a description method to all the json_spec matchers

### DIFF
--- a/lib/json_spec/matchers.rb
+++ b/lib/json_spec/matchers.rb
@@ -49,6 +49,12 @@ module JsonSpec
         message
       end
 
+      def description
+        message = "equal JSON"
+        message << %( at path "#{@path}") if @path
+        message
+      end
+
       private
         def scrub(json, path = nil)
           generate_normalized_json(exclude_keys(parse_json(json, path))).chomp + "\n"
@@ -99,6 +105,12 @@ module JsonSpec
         message << %( at path "#{@path}") if @path
         message
       end
+
+      def description
+        message = "include JSON"
+        message << %( at path "#{@path}") if @path
+        message
+      end
     end
 
     class HaveJsonPath
@@ -126,7 +138,7 @@ module JsonSpec
       end
 
       def description
-        "have json path"
+        %(have JSON path "#{@path}")
       end
     end
 
@@ -158,6 +170,12 @@ module JsonSpec
         message << %( at path "#{@path}") if @path
         message
       end
+
+      def description
+        message = %(have JSON type "#{@klass.to_s}")
+        message << %( at path "#{@path}") if @path
+        message
+      end
     end
 
     class HaveJsonSize
@@ -186,6 +204,12 @@ module JsonSpec
 
       def failure_message_for_should_not
         message = "Expected JSON value size to not be #{@expected}, got #{@actual}"
+        message << %( at path "#{@path}") if @path
+        message
+      end
+
+      def description
+        message = %(have JSON size "#{@expected}")
         message << %( at path "#{@path}") if @path
         message
       end

--- a/spec/json_spec/matchers_spec.rb
+++ b/spec/json_spec/matchers_spec.rb
@@ -86,6 +86,18 @@ describe "Matchers:" do
       JsonSpec.excluded_keys = %w(id json)
       %({"id":1,"json":"spec"}).should_not be_json_eql(%({"id":2,"json":"different"})).including(:id, :json)
     end
+
+    it "provide a description message" do
+      matcher = be_json_eql(%({"id":2,"json":"spec"}))
+      matcher.matches?(%({"id":1,"json":"spec"}))
+      matcher.description.should == "equal JSON"
+    end
+
+    it "provide a description message with path" do
+      matcher = be_json_eql(%({"id":1,"json":["spec"]})).at_path("json/0")
+      matcher.matches?(%({"id":1,"json":["spec"]}))
+      matcher.description.should == %(equal JSON at path "json/0")
+    end
   end
 
   context "include_json" do
@@ -140,6 +152,18 @@ describe "Matchers:" do
     it "ignores excluded keys" do
       %([{"id":1,"two":3}]).should include_json(%({"two":3}))
     end
+
+    it "provide a description message" do
+      matcher = include_json(%({"json":"spec"}))
+      matcher.matches?(%({"id":1,"json":"spec"}))
+      matcher.description.should == "include JSON"
+    end
+
+    it "provide a description message with path" do
+      matcher = include_json(%("spec")).at_path("json/0")
+      matcher.matches?(%({"id":1,"json":["spec"]}))
+      matcher.description.should == %(include JSON at path "json/0")
+    end
   end
 
   context "have_json_size" do
@@ -174,6 +198,18 @@ describe "Matchers:" do
       matcher.matches?(%([1,2,3]))
       matcher.failure_message_for_should_not.should == "Expected JSON value size to not be 3, got 3"
     end
+
+    it "provide a description message" do
+      matcher = have_json_size(1)
+      matcher.matches?(%({"id":1,"json":["spec"]}))
+      matcher.description.should == %(have JSON size "1")
+    end
+
+    it "provide a description message with path" do
+      matcher = have_json_size(1).at_path("json")
+      matcher.matches?(%({"id":1,"json":["spec"]}))
+      matcher.description.should == %(have JSON size "1" at path "json")
+    end
   end
 
   context "have_json_path" do
@@ -196,6 +232,13 @@ describe "Matchers:" do
     it "matches hash keys and array indexes" do
       %({"one":[1,2,{"three":4}]}).should have_json_path("one/2/three")
     end
+
+    it "provide a description message" do
+      matcher = have_json_path("json")
+      matcher.matches?(%({"id":1,"json":"spec"}))
+      matcher.description.should == %(have JSON path "json")
+    end
+
   end
 
   context "have_json_type" do
@@ -247,6 +290,18 @@ describe "Matchers:" do
       matcher = have_json_type(Numeric)
       matcher.matches?(%(10))
       matcher.failure_message_for_should_not.should == "Expected JSON value type to not be Numeric, got Fixnum"
+    end
+
+    it "provide a description message" do
+      matcher = have_json_type(String)
+      matcher.matches?(%({"id":1,"json":"spec"}))
+      matcher.description.should == %(have JSON type "String")
+    end
+
+    it "provide a description message with path" do
+      matcher = have_json_type(String).at_path("json")
+      matcher.matches?(%({"id":1,"json":"spec"}))
+      matcher.description.should == %(have JSON type "String" at path "json")
     end
 
     context "somewhat uselessly" do


### PR DESCRIPTION
I started using json_spec today and discovered that it didn't work well in rspec when using the subject shorthand.

``` ruby
    describe "GET index as JSON" do
      before :each do
        get :index, :format => :json
      end
      subject { response.body }
      it { should have_json_size(2) }
    end
```

As the 'it' block doesn't include a description it relies on the matcher to have a description method so that rspec can provided some useful output. 

I've added a simple description method to each of the json_spec matchers and provided spec for each.

This is the first time I've submitted a pull request so let me know if I need to provide some more info.
