### PR TITLE
have_json_fields matcher

### DIFF
--- a/lib/json_spec/matchers.rb
+++ b/lib/json_spec/matchers.rb
@@ -3,6 +3,7 @@ require "json_spec/matchers/include_json"
 require "json_spec/matchers/have_json_path"
 require "json_spec/matchers/have_json_type"
 require "json_spec/matchers/have_json_size"
+require "json_spec/matchers/have_json_fields"
 
 module JsonSpec
   module Matchers
@@ -24,6 +25,10 @@ module JsonSpec
 
     def have_json_size(size)
       JsonSpec::Matchers::HaveJsonSize.new(size)
+    end
+
+    def have_json_fields(size)
+      JsonSpec::Matchers::HaveJsonFields.new(size)
     end
   end
 end

--- a/lib/json_spec/matchers/have_json_fields.rb
+++ b/lib/json_spec/matchers/have_json_fields.rb
@@ -1,0 +1,35 @@
+module JsonSpec
+  module Matchers
+    class HaveJsonFields
+      include JsonSpec::Helpers
+      include JsonSpec::Messages
+
+      def initialize(fields)
+        @fields = fields
+      end
+
+      def matches?(json)
+        @data = parse_json(json, @path)
+        return false unless @data.is_a?(Hash)
+        !@fields.map{|f| @data.has_key?(f)}.include?(false)
+      end
+
+      def at_path(path)
+        @path = path
+        self
+      end
+
+      def failure_message_for_should
+        message_with_path("Expected JSON to contain all of the following fields #{@fields.join(", ")}")
+      end
+
+      def failure_message_for_should_not
+        message_with_path("Expected JSON to not contain any of the following fields #{@fields.join(", ")}")
+      end
+
+      def description
+        message_with_path(%(have JSON fields "#{@fields.join(", ")}"))
+      end
+    end
+  end
+end

--- a/spec/json_spec/matchers/have_json_fields_spec.rb
+++ b/spec/json_spec/matchers/have_json_fields_spec.rb
@@ -1,0 +1,17 @@
+require "spec_helper"
+
+describe JsonSpec::Matchers::HaveJsonFields do
+  it "fails for non-hashes" do
+    %([1,2,3]).should_not have_json_fields([])
+    %(1).should_not have_json_fields([])
+    %("test").should_not have_json_fields([])
+  end
+
+  it "fails for non-complete set of fields" do
+    %({"a": "a", "b": "b"}).should_not have_json_fields(%w(a b c))
+  end
+
+  it "matches complete set of fields" do
+    %({"a": "a", "b": "b", "c": "c"}).should have_json_fields(%w(a b c))
+  end
+end


### PR DESCRIPTION
This matcher allows to check existence of fields set ignoring their values. Can be useful for highly-random large hashes acceptance testing.

``` ruby
%({"a": "a", "b": "b", "c": "c"}).should have_json_fields(%w(a b c))
```
