### PR TITLE
Update for deprecations in multi_json 1.3.0

### DIFF
--- a/json_spec.gemspec
+++ b/json_spec.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |gem|
   gem.description = "Easily handle JSON in RSpec and Cucumber"
   gem.homepage    = "https://github.com/collectiveidea/json_spec"
 
-  gem.add_dependency "multi_json", "~> 1.0"
+  gem.add_dependency "multi_json", "~> 1.0", "< 1.3.0"
   gem.add_dependency "rspec",      "~> 2.0"
 
   gem.add_development_dependency "cucumber", "~> 1.1", ">= 1.1.1"


### PR DESCRIPTION
This cleans up some deprecation warnings when using json_spec with multi_json >= 1.3.0. It feels better to bump the multi_json dependency rather than put in begin/rescue blocks to handle fallback to the older methods if the new code doesn't work, so the gemspec was also updated.
