### PR TITLE
removing feature detect

### DIFF
--- a/lib/json_spec/helpers.rb
+++ b/lib/json_spec/helpers.rb
@@ -32,7 +32,7 @@ module JsonSpec
 
     private
       def multi_json_load(json)
-        MultiJson.respond_to?(:load) ? MultiJson.load(json) : MultiJson.decode(json)
+        MultiJson.decode(json)
       end
 
       def value_at_json_path(ruby, path)


### PR DESCRIPTION
thanks to new 1.3.4 multi_json, there's no need to feature detect.

https://github.com/collectiveidea/json_spec/issues/27

```
  sferik commented 2 hours ago
  There's no longer a need to feature-detect in the latest version of MultiJson (1.3.4). decode is an alias of  load that no longer prints deprecation warnings.
```
