### PR TITLE
Helpers#parse_json to not parse unless a String

### DIFF
--- a/lib/json_spec/helpers.rb
+++ b/lib/json_spec/helpers.rb
@@ -5,7 +5,7 @@ module JsonSpec
     extend self
 
     def parse_json(json, path = nil)
-      ruby = MultiJson.decode("[#{json}]").first
+      ruby = json.is_a?(String) ? MultiJson.decode("[#{json}]").first : json
       value_at_json_path(ruby, path)
     rescue MultiJson::DecodeError
       MultiJson.decode(json)

--- a/spec/json_spec/helpers_spec.rb
+++ b/spec/json_spec/helpers_spec.rb
@@ -28,6 +28,11 @@ describe JsonSpec::Helpers do
         expect{ parse_json(json, path) }.to raise_error(JsonSpec::MissingPath)
       end
     end
+
+    it "does not parse when not a string" do
+      json = { :json => ["spec"] }
+      parse_json( json ).should == json
+    end
   end
 
   context "normalize_json" do


### PR DESCRIPTION
Hi,

I currently have a setup that had a `last_json` method already implemented before migrating to json_spec for cucumber testing. The method already returned a parsed JSON, which is not compatible since json_spec wants to parse it again from a string.

I committed a change to only parse the JSON in case it's a string (else return the given option). I can't see a reason why `last_json` should only be the `last_response.body` string (or similar) and not already a Hash/Array.

Would that be something you could merge into the main branch?

Best, 
Rudi
