### PR TITLE
make "the JSON should have the following" not skip the first assertion

### DIFF
--- a/lib/json_spec/cucumber.rb
+++ b/lib/json_spec/cucumber.rb
@@ -59,7 +59,7 @@ Then /^the (?:JSON|json)(?: response)?(?: at "(.*)")? should( not)? include (".*
 end
 
 Then /^the (?:JSON|json)(?: response)?(?: at "(.*)")? should have the following:$/ do |base, table|
-  table.rows.each do |path, value|
+  table.raw.each do |path, value|
     path = [base, path].compact.join("/")
 
     if value


### PR DESCRIPTION
when using the `Then the JSON should have the following`-assertion in cucumber like so:

```
Then the JSON should have the following:
  | string  | "string  |
  | integer | 42       |
```

the first line of the table was interpreted as a table header and skipped. The attached patch fixes that.

I don't really know how to write a proper test for that.
