### PR TITLE
Extend include_json to match elements inside an array of hash

### DIFF
--- a/spec/json_spec/matchers/include_json_spec.rb
+++ b/spec/json_spec/matchers/include_json_spec.rb
@@ -29,6 +29,16 @@ describe JsonSpec::Matchers::IncludeJson do
     json.should include_json(%({"name":"lily"}))
   end
 
+  it "matches sub hashes inside a hash" do
+    json = %({"string":"one","integer":1,"float":1.0,"true":true,"false":false,"null":null})
+    json.should include_json(%({"string":"one"}))
+    json.should include_json(%({"integer":1}))
+    json.should include_json(%({"float":1.0}))
+    json.should include_json(%({"true":true}))
+    json.should include_json(%({"false":false}))
+    json.should include_json(%({"null":null}))
+  end
+
   it "matches included hash values" do
     json = %({"string":"one","integer":1,"float":1.0,"true":true,"false":false,"null":null})
     json.should include_json(%("one"))


### PR DESCRIPTION
Background:
Right now include_json can't test a specific element inside a hash that is included in an array. 
I understand that the package comes with exclude_keys, but it'd be handy if it can only match up the elements that I care about.
# Use case

Given actual (json object) and expected(hash):

JSON.parse(actual)
[{"user1" => {"name" => "Mike", "gender" => "male"}}, {"user2" => {"name" => "Abby", "gender" => "female"}}]

expected
{"name" => "Abby", "gender" => "female"}

actual.should include_json(expected.to_json)

> false

This patch will make the following truthy:

actual.should include_json(expected.to_json)

> true
