### PR TITLE
provide better failure message for include_json class

### DIFF
--- a/lib/json_spec/matchers/include_json.rb
+++ b/lib/json_spec/matchers/include_json.rb
@@ -12,6 +12,8 @@ module JsonSpec
       def matches?(actual_json)
         raise "Expected included JSON not provided" if @expected_json.nil?
 
+        @actual_json = actual_json
+
         actual = parse_json(actual_json, @path)
         expected = exclude_keys(parse_json(@expected_json))
         case actual
@@ -43,11 +45,11 @@ module JsonSpec
       end
 
       def failure_message_for_should
-        message_with_path("Expected included JSON")
+        message_with_path("Expected #{@actual_json} included #{@expected_json}")
       end
 
       def failure_message_for_should_not
-        message_with_path("Expected excluded JSON")
+        message_with_path("Expected #{@actual_json} excluded #{@expected_json}")
       end
 
       def description

--- a/spec/json_spec/matchers/include_json_spec.rb
+++ b/spec/json_spec/matchers/include_json_spec.rb
@@ -59,6 +59,18 @@ describe JsonSpec::Matchers::IncludeJson do
     %([{"id":1,"two":3}]).should include_json(%({"two":3}))
   end
 
+  it "provides a failure message for should" do
+    matcher = include_json(%({"json":"spec"}))
+    matcher.matches?(%({"foo":"bar"}))
+    matcher.failure_message_for_should.should == "Expected {\"foo\":\"bar\"} included {\"json\":\"spec\"}"
+  end
+
+  it "provides a failure message for should not" do
+    matcher = include_json(%("foo"))
+    matcher.matches?(%(["foo","bar", 1]))
+    matcher.failure_message_for_should_not.should == "Expected [\"foo\",\"bar\", 1] excluded \"foo\""
+  end
+
   it "provides a description message" do
     matcher = include_json(%({"json":"spec"}))
     matcher.matches?(%({"id":1,"json":"spec"}))


### PR DESCRIPTION
Background:
When include_json spec fails, the information was "Expected included JSON" or "Expected excluded JSON". It is not very informative, thus this pull request.

In this PR, the following message will throw for a include_json case

``` ruby
%([[1,2,3],[4,5,6]]).should include_json(%([1,2]))

  1) JsonSpec::Matchers::IncludeJson matches an array included in an array
     Failure/Error: json.should include_json(%([1,2]))
       Expected [[1,2,3],[4,5,6]] included [1,2]
```
