### PR TITLE
Add with_content chain to have_json_path matcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ describe User do
     end
 
     it "includes the ID" do
-      user.to_json.should have_json_path("id")
+      user.to_json.should have_json_path("id").with_content(1)
       user.to_json.should have_json_type(Integer).at_path("id")
     end
 

--- a/lib/json_spec/matchers/have_json_path.rb
+++ b/lib/json_spec/matchers/have_json_path.rb
@@ -8,22 +8,36 @@ module JsonSpec
       end
 
       def matches?(json)
-        parse_json(json, @path)
+        obj = parse_json(json, @path)
+        if @content
+          return false unless @content.eql?(obj)
+        end
         true
       rescue JsonSpec::MissingPath
         false
       end
 
+      def with_content(content)
+        @content = content
+        self
+      end
+
       def failure_message_for_should
-        %(Expected JSON path "#{@path}")
+        message = %(Expected JSON path "#{@path}")
+        message += %( with content "#{@content}") if @content
+        message
       end
 
       def failure_message_for_should_not
-        %(Expected no JSON path "#{@path}")
+        message = %(Expected no JSON path "#{@path}")
+        message += %( with content "#{@content}") if @content
+        message
       end
 
       def description
-        %(have JSON path "#{@path}")
+        message = %(have JSON path "#{@path}")
+        message += %( with content "#{@content}") if @content
+        message
       end
     end
   end

--- a/spec/json_spec/matchers/have_json_path_spec.rb
+++ b/spec/json_spec/matchers/have_json_path_spec.rb
@@ -26,4 +26,12 @@ describe JsonSpec::Matchers::HaveJsonPath do
     matcher.matches?(%({"id":1,"json":"spec"}))
     matcher.description.should == %(have JSON path "json")
   end
+
+  it "compares the content" do
+    %({"one":{"two":{"three":4}}}).should have_json_path("one/two/three").with_content(4)
+  end
+
+  it "doesn't match incorrect content" do
+    %({"one":{"two":{"three":4}}}).should_not have_json_path("one/two/three").with_content(3)
+  end
 end


### PR DESCRIPTION
This PR adds a with_content() chain to the have_json_path matcher, which compares the content at the path with the one provided. I've found myself regularly in the position where not only the fact that the JSON path existed was important to me, but also the content. Of course you could split up this expectation up into two independent ones, but I think the with_content() makes the thing a lot easier.

I'm not totally happy with the failure messages - open for comments!
