### PR TITLE
Add #only to whitelist keys

### DIFF
--- a/lib/json_spec/exclusion.rb
+++ b/lib/json_spec/exclusion.rb
@@ -16,11 +16,19 @@ module JsonSpec
     end
 
     def exclude_key?(key)
-      excluded_keys.include?(key)
+      if only_keys.empty?
+        excluded_keys.include?(key)
+      else
+        !only_keys.include?(key)
+      end
     end
 
     def excluded_keys
       @excluded_keys ||= Set.new(JsonSpec.excluded_keys)
+    end
+
+    def only_keys
+      @only_keys ||= Set.new
     end
   end
 end

--- a/lib/json_spec/matchers/be_json_eql.rb
+++ b/lib/json_spec/matchers/be_json_eql.rb
@@ -42,6 +42,11 @@ module JsonSpec
         self
       end
 
+      def only(*keys)
+        only_keys.merge(keys.map(&:to_s))
+        self
+      end
+
       def failure_message_for_should
         message_with_path("Expected equivalent JSON")
       end

--- a/lib/json_spec/matchers/include_json.rb
+++ b/lib/json_spec/matchers/include_json.rb
@@ -42,6 +42,11 @@ module JsonSpec
         self
       end
 
+      def only(*keys)
+        only_keys.merge(keys.map(&:to_s))
+        self
+      end
+
       def failure_message_for_should
         message_with_path("Expected included JSON")
       end

--- a/spec/json_spec/matchers/be_json_eql_spec.rb
+++ b/spec/json_spec/matchers/be_json_eql_spec.rb
@@ -86,6 +86,11 @@ describe JsonSpec::Matchers::BeJsonEql do
     %({"id":1,"json":"spec"}).should_not be_json_eql(%({"id":2,"json":"different"})).including(:id, :json)
   end
 
+  it 'matching only the specified keys' do
+    JsonSpec.excluded_keys = []
+    %({"id":1,"json":"spec"}).should be_json_eql(%({"id":1})).only(:id)
+  end
+
   it "provides a description message" do
     matcher = be_json_eql(%({"id":2,"json":"spec"}))
     matcher.matches?(%({"id":1,"json":"spec"}))

--- a/spec/json_spec/matchers/include_json_spec.rb
+++ b/spec/json_spec/matchers/include_json_spec.rb
@@ -59,6 +59,10 @@ describe JsonSpec::Matchers::IncludeJson do
     %([{"id":1,"two":3}]).should include_json(%({"two":3}))
   end
 
+  it 'matching only the specified keys' do
+    %([{"id":1,"json":"spec"}]).should include_json(%({"id":1})).only(:id)
+  end
+
   it "provides a description message" do
     matcher = include_json(%({"json":"spec"}))
     matcher.matches?(%({"id":1,"json":"spec"}))


### PR DESCRIPTION
In my integration request specs, I sometimes want to find out if a json response contains objects with specific ids.  With the existing interface I have to go through and explicitly blacklist all of the other keys.  I instead added a whitelist with the #only method.

Example:

``` ruby
# include_json
%([{"id":1,"json":"spec"}]).should include_json(%({"id":1})).only(:id)

# be_json_eql
%({"id":1,"json":"spec"}).should be_json_eql(%({"id":1})).only(:id)
```

The actual json responses I'm comparing have far more keys.
