### PR TITLE
Update exclusion

### DIFF
--- a/features/equivalence.feature
+++ b/features/equivalence.feature
@@ -97,6 +97,7 @@ Feature: Equivalence
           "json",
           "spec"
         ],
+        "created_at": "2000-01-01 00:00:00",
         "empty_array": [
 
         ],
@@ -107,11 +108,13 @@ Feature: Equivalence
         "hash": {
           "json": "spec"
         },
+        "id": 2,
         "integer": 10,
         "negative": -10,
         "null": null,
         "string": "json_spec",
-        "true": true
+        "true": true,
+        "updated_at": "2006-06-06 06:06:06"
       }
       """
 

--- a/features/inclusion.feature
+++ b/features/inclusion.feature
@@ -151,4 +151,4 @@ Feature: Inclusion
 
   Scenario: Nested exclusions
     When I get the JSON
-    Then the JSON should include {"key":"value"}
+    Then the JSON should include {"id": 3, "key":"value"}

--- a/lib/json_spec/exclusion.rb
+++ b/lib/json_spec/exclusion.rb
@@ -6,7 +6,7 @@ module JsonSpec
       case ruby
       when Hash
         ruby.sort.inject({}) do |hash, (key, value)|
-          hash[key] = exclude_keys(value) unless exclude_key?(key)
+          hash[key] = exclude_key?(key) ? 1 : exclude_keys(value)
           hash
         end
       when Array

--- a/spec/json_spec/matchers/be_json_eql_spec.rb
+++ b/spec/json_spec/matchers/be_json_eql_spec.rb
@@ -33,14 +33,9 @@ describe JsonSpec::Matchers::BeJsonEql do
     actual.to_json.should be_json_eql(expected.to_json)
   end
 
-  it "ignores custom excluded hash keys" do
-    JsonSpec.exclude_keys("ignore")
-    %({"json":"spec","ignore":"please"}).should be_json_eql(%({"json":"spec"}))
-  end
-
   it "ignores nested, excluded hash keys" do
     JsonSpec.exclude_keys("ignore")
-    %({"json":"spec","please":{"ignore":"this"}}).should be_json_eql(%({"json":"spec","please":{}}))
+    %({"json":"spec","please":{"ignore":"this"}}).should be_json_eql(%({"json":"spec","please":{"ignore":"that"}}))
   end
 
   it "ignores hash keys when included in the expected value" do

--- a/spec/json_spec/matchers/include_json_spec.rb
+++ b/spec/json_spec/matchers/include_json_spec.rb
@@ -56,7 +56,7 @@ describe JsonSpec::Matchers::IncludeJson do
   end
 
   it "ignores excluded keys" do
-    %([{"id":1,"two":3}]).should include_json(%({"two":3}))
+    %([{"id":1,"two":3}]).should include_json(%({"id":2,"two":3}))
   end
 
   it "provides a description message" do


### PR DESCRIPTION
Because excluded keys are simply removed from all hashes, be_json_eql is not testing for their presence. Keys are excluded because we can't guarantee the value will match (id, created_at, updated_at). By removing them we avoid the conflicting values but we lose the check for presence. I solved this by instead setting the value of excluded keys to 1. This way we no longer care about conflicting values and retain the presence check. 