### PR TITLE
Update tests to support RSpec 3.0.0.beta1

### DIFF
--- a/json_spec.gemspec
+++ b/json_spec.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |gem|
   gem.license     = "MIT"
 
   gem.add_dependency "multi_json", "~> 1.0"
-  gem.add_dependency "rspec", "~> 2.0"
+  gem.add_dependency "rspec", ">= 2.14.1"
 
   gem.add_development_dependency "bundler", "~> 1.0"
 

--- a/spec/json_spec/configuration_spec.rb
+++ b/spec/json_spec/configuration_spec.rb
@@ -2,61 +2,61 @@ require "spec_helper"
 
 describe JsonSpec::Configuration do
   it "excludes id and timestamps by default" do
-    JsonSpec.excluded_keys.should == ["id", "created_at", "updated_at"]
+    expect(JsonSpec.excluded_keys).to eq(["id", "created_at", "updated_at"])
   end
 
   it "excludes custom keys" do
     JsonSpec.exclude_keys("token")
-    JsonSpec.excluded_keys.should == ["token"]
+    expect(JsonSpec.excluded_keys).to eq(["token"])
   end
 
   it "excludes custom keys via setter" do
     JsonSpec.excluded_keys = ["token"]
-    JsonSpec.excluded_keys.should == ["token"]
+    expect(JsonSpec.excluded_keys).to eq(["token"])
   end
 
   it "excludes custom keys via block" do
     JsonSpec.configure{|c| c.exclude_keys("token") }
-    JsonSpec.excluded_keys.should == ["token"]
+    expect(JsonSpec.excluded_keys).to eq(["token"])
   end
 
   it "excludes custom keys via block setter" do
     JsonSpec.configure{|c| c.excluded_keys = ["token"] }
-    JsonSpec.excluded_keys.should == ["token"]
+    expect(JsonSpec.excluded_keys).to eq(["token"])
   end
 
   it "excludes custom keys via instance-evaluated block" do
     JsonSpec.configure{ exclude_keys("token") }
-    JsonSpec.excluded_keys.should == ["token"]
+    expect(JsonSpec.excluded_keys).to eq(["token"])
   end
 
   it "ensures its excluded keys are strings" do
     JsonSpec.exclude_keys(:token)
-    JsonSpec.excluded_keys.should == ["token"]
+    expect(JsonSpec.excluded_keys).to eq(["token"])
   end
 
   it "ensures its excluded keys are unique" do
     JsonSpec.exclude_keys("token", :token)
-    JsonSpec.excluded_keys.should == ["token"]
+    expect(JsonSpec.excluded_keys).to eq(["token"])
   end
 
   it "resets its excluded keys" do
     original = JsonSpec.excluded_keys
 
     JsonSpec.exclude_keys("token")
-    JsonSpec.excluded_keys.should_not == original
+    expect(JsonSpec.excluded_keys).not_to eq(original)
 
     JsonSpec.reset
-    JsonSpec.excluded_keys.should == original
+    expect(JsonSpec.excluded_keys).to eq(original)
   end
 
   it "resets its directory" do
-    JsonSpec.directory.should be_nil
+    expect(JsonSpec.directory).to be_nil
 
     JsonSpec.directory = "/"
-    JsonSpec.directory.should_not be_nil
+    expect(JsonSpec.directory).not_to be_nil
 
     JsonSpec.reset
-    JsonSpec.directory.should be_nil
+    expect(JsonSpec.directory).to be_nil
   end
 end

--- a/spec/json_spec/helpers_spec.rb
+++ b/spec/json_spec/helpers_spec.rb
@@ -5,11 +5,11 @@ describe JsonSpec::Helpers do
 
   context "parse_json" do
     it "parses JSON documents" do
-      parse_json(%({"json":["spec"]})).should == {"json" => ["spec"]}
+      expect(parse_json(%({"json":["spec"]}))).to eq({"json" => ["spec"]})
     end
 
     it "parses JSON values" do
-      parse_json(%("json_spec")).should == "json_spec"
+      expect(parse_json(%("json_spec"))).to eq("json_spec")
     end
 
     it "raises a parser error for invalid JSON" do
@@ -18,8 +18,8 @@ describe JsonSpec::Helpers do
 
     it "parses at a path if given" do
       json = %({"json":["spec"]})
-      parse_json(json, "json").should == ["spec"]
-      parse_json(json, "json/0").should == "spec"
+      expect(parse_json(json, "json")).to eq(["spec"])
+      expect(parse_json(json, "json/0")).to eq("spec")
     end
 
     it "raises an error for a missing path" do
@@ -31,7 +31,7 @@ describe JsonSpec::Helpers do
 
     it "parses at a numeric string path" do
       json = %({"1":"two"})
-      parse_json(%({"1":"two"}), "1").should == "two"
+      expect(parse_json(%({"1":"two"}), "1")).to eq("two")
     end
   end
 
@@ -44,19 +44,19 @@ describe JsonSpec::Helpers do
   ]
 }
       JSON
-      normalize_json(%({"json":["spec"]})).should == normalized.chomp
+      expect(normalize_json(%({"json":["spec"]}))).to eq(normalized.chomp)
     end
 
     it "normalizes at a path" do
-      normalize_json(%({"json":["spec"]}), "json/0").should == %("spec")
+      expect(normalize_json(%({"json":["spec"]}), "json/0")).to eq(%("spec"))
     end
 
     it "accepts a JSON value" do
-      normalize_json(%("json_spec")).should == %("json_spec")
+      expect(normalize_json(%("json_spec"))).to eq(%("json_spec"))
     end
 
     it "normalizes JSON values" do
-      normalize_json(%(1e+1)).should == %(10.0)
+      expect(normalize_json(%(1e+1))).to eq(%(10.0))
     end
   end
 
@@ -69,11 +69,11 @@ describe JsonSpec::Helpers do
   ]
 }
       JSON
-      generate_normalized_json({"json" => ["spec"]}).should == normalized.chomp
+      expect(generate_normalized_json({"json" => ["spec"]})).to eq(normalized.chomp)
     end
 
     it "generates a normalized JSON value" do
-      generate_normalized_json(nil).should == %(null)
+      expect(generate_normalized_json(nil)).to eq(%(null))
     end
   end
 
@@ -84,12 +84,12 @@ describe JsonSpec::Helpers do
 
     it "returns JSON when the file exists" do
       JsonSpec.directory = files_path
-      load_json("one.json").should == %({"value":"from_file"})
+      expect(load_json("one.json")).to eq(%({"value":"from_file"}))
     end
 
     it "ignores extra slashes" do
       JsonSpec.directory = "/#{files_path}/"
-      load_json("one.json").should == %({"value":"from_file"})
+      expect(load_json("one.json")).to eq(%({"value":"from_file"}))
     end
 
     it "raises an error when the file doesn't exist" do
@@ -104,8 +104,8 @@ describe JsonSpec::Helpers do
 
     it "finds nested files" do
       JsonSpec.directory = files_path
-      load_json("project/one.json").should == %({"nested":"inside_folder"})
-      load_json("project/version/one.json").should == %({"nested":"deeply"})
+      expect(load_json("project/one.json")).to eq(%({"nested":"inside_folder"}))
+      expect(load_json("project/version/one.json")).to eq(%({"nested":"deeply"}))
     end
   end
 end

--- a/spec/json_spec/matchers/be_json_eql_spec.rb
+++ b/spec/json_spec/matchers/be_json_eql_spec.rb
@@ -2,108 +2,108 @@ require "spec_helper"
 
 describe JsonSpec::Matchers::BeJsonEql do
   it "matches identical JSON" do
-    %({"json":"spec"}).should be_json_eql(%({"json":"spec"}))
+    expect(%({"json":"spec"})).to be_json_eql(%({"json":"spec"}))
   end
 
   it "matches differently-formatted JSON" do
-    %({"json": "spec"}).should be_json_eql(%({"json":"spec"}))
+    expect(%({"json": "spec"})).to be_json_eql(%({"json":"spec"}))
   end
 
   it "matches out-of-order hashes" do
-    %({"laser":"lemon","json":"spec"}).should be_json_eql(%({"json":"spec","laser":"lemon"}))
+    expect(%({"laser":"lemon","json":"spec"})).to be_json_eql(%({"json":"spec","laser":"lemon"}))
   end
 
   it "doesn't match out-of-order arrays" do
-    %(["json","spec"]).should_not be_json_eql(%(["spec","json"]))
+    expect(%(["json","spec"])).not_to be_json_eql(%(["spec","json"]))
   end
 
   it "matches valid JSON values, yet invalid JSON documents" do
-    %("json_spec").should be_json_eql(%("json_spec"))
+    expect(%("json_spec")).to be_json_eql(%("json_spec"))
   end
 
   it "matches at a path" do
-    %({"json":["spec"]}).should be_json_eql(%("spec")).at_path("json/0")
+    expect(%({"json":["spec"]})).to be_json_eql(%("spec")).at_path("json/0")
   end
 
   it "ignores excluded-by-default hash keys" do
-    JsonSpec.excluded_keys.should_not be_empty
+    expect(JsonSpec.excluded_keys).not_to be_empty
 
     actual = expected = {"json" => "spec"}
     JsonSpec.excluded_keys.each{|k| actual[k] = k }
-    actual.to_json.should be_json_eql(expected.to_json)
+    expect(actual.to_json).to be_json_eql(expected.to_json)
   end
 
   it "ignores custom excluded hash keys" do
     JsonSpec.exclude_keys("ignore")
-    %({"json":"spec","ignore":"please"}).should be_json_eql(%({"json":"spec"}))
+    expect(%({"json":"spec","ignore":"please"})).to be_json_eql(%({"json":"spec"}))
   end
 
   it "ignores nested, excluded hash keys" do
     JsonSpec.exclude_keys("ignore")
-    %({"json":"spec","please":{"ignore":"this"}}).should be_json_eql(%({"json":"spec","please":{}}))
+    expect(%({"json":"spec","please":{"ignore":"this"}})).to be_json_eql(%({"json":"spec","please":{}}))
   end
 
   it "ignores hash keys when included in the expected value" do
     JsonSpec.exclude_keys("ignore")
-    %({"json":"spec","ignore":"please"}).should be_json_eql(%({"json":"spec","ignore":"this"}))
+    expect(%({"json":"spec","ignore":"please"})).to be_json_eql(%({"json":"spec","ignore":"this"}))
   end
 
   it "doesn't match Ruby-equivalent, JSON-inequivalent values" do
-    %({"one":1}).should_not be_json_eql(%({"one":1.0}))
+    expect(%({"one":1})).not_to be_json_eql(%({"one":1.0}))
   end
 
   it "matches different looking, JSON-equivalent values" do
-    %({"ten":10.0}).should be_json_eql(%({"ten":1e+1}))
+    expect(%({"ten":10.0})).to be_json_eql(%({"ten":1e+1}))
   end
 
   it "excludes extra hash keys per matcher" do
     JsonSpec.excluded_keys = %w(ignore)
-    %({"id":1,"json":"spec","ignore":"please"}).should be_json_eql(%({"id":2,"json":"spec","ignore":"this"})).excluding("id")
+    expect(%({"id":1,"json":"spec","ignore":"please"})).to be_json_eql(%({"id":2,"json":"spec","ignore":"this"})).excluding("id")
   end
 
   it "excludes extra hash keys given as symbols" do
     JsonSpec.excluded_keys = []
-    %({"id":1,"json":"spec"}).should be_json_eql(%({"id":2,"json":"spec"})).excluding(:id)
+    expect(%({"id":1,"json":"spec"})).to be_json_eql(%({"id":2,"json":"spec"})).excluding(:id)
   end
 
   it "excludes multiple keys" do
     JsonSpec.excluded_keys = []
-    %({"id":1,"json":"spec"}).should be_json_eql(%({"id":2,"json":"different"})).excluding(:id, :json)
+    expect(%({"id":1,"json":"spec"})).to be_json_eql(%({"id":2,"json":"different"})).excluding(:id, :json)
   end
 
   it "includes globally-excluded hash keys per matcher" do
     JsonSpec.excluded_keys = %w(id ignore)
-    %({"id":1,"json":"spec","ignore":"please"}).should_not be_json_eql(%({"id":2,"json":"spec","ignore":"this"})).including("id")
+    expect(%({"id":1,"json":"spec","ignore":"please"})).not_to be_json_eql(%({"id":2,"json":"spec","ignore":"this"})).including("id")
   end
 
   it "includes globally-included hash keys given as symbols" do
     JsonSpec.excluded_keys = %w(id)
-    %({"id":1,"json":"spec"}).should_not be_json_eql(%({"id":2,"json":"spec"})).including(:id)
+    expect(%({"id":1,"json":"spec"})).not_to be_json_eql(%({"id":2,"json":"spec"})).including(:id)
   end
 
   it "includes multiple keys" do
     JsonSpec.excluded_keys = %w(id json)
-    %({"id":1,"json":"spec"}).should_not be_json_eql(%({"id":2,"json":"different"})).including(:id, :json)
+    expect(%({"id":1,"json":"spec"})).not_to be_json_eql(%({"id":2,"json":"different"})).including(:id, :json)
   end
 
   it "provides a description message" do
     matcher = be_json_eql(%({"id":2,"json":"spec"}))
     matcher.matches?(%({"id":1,"json":"spec"}))
-    matcher.description.should == "equal JSON"
+    expect(matcher.description).to eq("equal JSON")
   end
 
   it "provides a description message with path" do
     matcher = be_json_eql(%({"id":1,"json":["spec"]})).at_path("json/0")
     matcher.matches?(%({"id":1,"json":["spec"]}))
-    matcher.description.should == %(equal JSON at path "json/0")
+    expect(matcher.description).to eq(%(equal JSON at path "json/0"))
   end
 
   it "raises an error when not given expected JSON" do
-    expect{ %({"id":1,"json":"spec"}).should be_json_eql }.to raise_error
+    expect{ expect(%({"id":1,"json":"spec"})).to be_json_eql }.to raise_error
   end
 
   it "matches file contents" do
     JsonSpec.directory = files_path
-    %({ "value" : "from_file" }).should be_json_eql.to_file("one.json")
+    expect(%({ "value" : "from_file" })).to be_json_eql.to_file("one.json")
   end
 end

--- a/spec/json_spec/matchers/have_json_path_spec.rb
+++ b/spec/json_spec/matchers/have_json_path_spec.rb
@@ -2,28 +2,28 @@ require "spec_helper"
 
 describe JsonSpec::Matchers::HaveJsonPath do
   it "matches hash keys" do
-    %({"one":{"two":{"three":4}}}).should have_json_path("one/two/three")
+    expect(%({"one":{"two":{"three":4}}})).to have_json_path("one/two/three")
   end
 
   it "doesn't match values" do
-    %({"one":{"two":{"three":4}}}).should_not have_json_path("one/two/three/4")
+    expect(%({"one":{"two":{"three":4}}})).not_to have_json_path("one/two/three/4")
   end
 
   it "matches array indexes" do
-    %([1,[1,2,[1,2,3,4]]]).should have_json_path("1/2/3")
+    expect(%([1,[1,2,[1,2,3,4]]])).to have_json_path("1/2/3")
   end
 
   it "respects null array values" do
-    %([null,[null,null,[null,null,null,null]]]).should have_json_path("1/2/3")
+    expect(%([null,[null,null,[null,null,null,null]]])).to have_json_path("1/2/3")
   end
 
   it "matches hash keys and array indexes" do
-    %({"one":[1,2,{"three":4}]}).should have_json_path("one/2/three")
+    expect(%({"one":[1,2,{"three":4}]})).to have_json_path("one/2/three")
   end
 
   it "provides a description message" do
     matcher = have_json_path("json")
     matcher.matches?(%({"id":1,"json":"spec"}))
-    matcher.description.should == %(have JSON path "json")
+    expect(matcher.description).to eq(%(have JSON path "json"))
   end
 end

--- a/spec/json_spec/matchers/have_json_size_spec.rb
+++ b/spec/json_spec/matchers/have_json_size_spec.rb
@@ -2,46 +2,46 @@ require "spec_helper"
 
 describe JsonSpec::Matchers::HaveJsonSize do
   it "counts array entries" do
-    %([1,2,3]).should have_json_size(3)
+    expect(%([1,2,3])).to have_json_size(3)
   end
 
   it "counts null array entries" do
-    %([1,null,3]).should have_json_size(3)
+    expect(%([1,null,3])).to have_json_size(3)
   end
 
   it "counts hash key/value pairs" do
-    %({"one":1,"two":2,"three":3}).should have_json_size(3)
+    expect(%({"one":1,"two":2,"three":3})).to have_json_size(3)
   end
 
   it "counts null hash values" do
-    %({"one":1,"two":null,"three":3}).should have_json_size(3)
+    expect(%({"one":1,"two":null,"three":3})).to have_json_size(3)
   end
 
   it "matches at a path" do
-    %({"one":[1,2,3]}).should have_json_size(3).at_path("one")
+    expect(%({"one":[1,2,3]})).to have_json_size(3).at_path("one")
   end
 
   it "provides a failure message for should" do
     matcher = have_json_size(3)
     matcher.matches?(%([1,2]))
-    matcher.failure_message_for_should.should == "Expected JSON value size to be 3, got 2"
+    expect(matcher.failure_message_for_should).to eq("Expected JSON value size to be 3, got 2")
   end
 
   it "provides a failure message for should not" do
     matcher = have_json_size(3)
     matcher.matches?(%([1,2,3]))
-    matcher.failure_message_for_should_not.should == "Expected JSON value size to not be 3, got 3"
+    expect(matcher.failure_message_for_should_not).to eq("Expected JSON value size to not be 3, got 3")
   end
 
   it "provides a description message" do
     matcher = have_json_size(1)
     matcher.matches?(%({"id":1,"json":["spec"]}))
-    matcher.description.should == %(have JSON size "1")
+    expect(matcher.description).to eq(%(have JSON size "1"))
   end
 
   it "provides a description message with path" do
     matcher = have_json_size(1).at_path("json")
     matcher.matches?(%({"id":1,"json":["spec"]}))
-    matcher.description.should == %(have JSON size "1" at path "json")
+    expect(matcher.description).to eq(%(have JSON size "1" at path "json"))
   end
 end

--- a/spec/json_spec/matchers/have_json_type_spec.rb
+++ b/spec/json_spec/matchers/have_json_type_spec.rb
@@ -3,87 +3,87 @@ require "spec_helper"
 describe JsonSpec::Matchers::HaveJsonType do
   it "matches hashes" do
     hash = %({})
-    hash.should have_json_type(Hash)
-    hash.should have_json_type(:object)
+    expect(hash).to have_json_type(Hash)
+    expect(hash).to have_json_type(:object)
   end
 
   it "matches arrays" do
-    %([]).should have_json_type(Array)
+    expect(%([])).to have_json_type(Array)
   end
 
   it "matches at a path" do
-    %({"root":[]}).should have_json_type(Array).at_path("root")
+    expect(%({"root":[]})).to have_json_type(Array).at_path("root")
   end
 
   it "matches strings" do
-    %(["json_spec"]).should have_json_type(String).at_path("0")
+    expect(%(["json_spec"])).to have_json_type(String).at_path("0")
   end
 
   it "matches a valid JSON value, yet invalid JSON document" do
-    %("json_spec").should have_json_type(String)
+    expect(%("json_spec")).to have_json_type(String)
   end
 
   it "matches empty strings" do
-    %("").should have_json_type(String)
+    expect(%("")).to have_json_type(String)
   end
 
   it "matches integers" do
-    %(10).should have_json_type(Integer)
+    expect(%(10)).to have_json_type(Integer)
   end
 
   it "matches floats" do
-    %(10.0).should have_json_type(Float)
-    %(1e+1).should have_json_type(Float)
+    expect(%(10.0)).to have_json_type(Float)
+    expect(%(1e+1)).to have_json_type(Float)
   end
 
   it "matches booleans" do
-    %(true).should have_json_type(:boolean)
-    %(false).should have_json_type(:boolean)
+    expect(%(true)).to have_json_type(:boolean)
+    expect(%(false)).to have_json_type(:boolean)
   end
 
   it "matches ancestor classes" do
-    %(10).should have_json_type(Numeric)
-    %(10.0).should have_json_type(Numeric)
+    expect(%(10)).to have_json_type(Numeric)
+    expect(%(10.0)).to have_json_type(Numeric)
   end
 
   it "provides a failure message for should" do
     matcher = have_json_type(Numeric)
     matcher.matches?(%("foo"))
-    matcher.failure_message_for_should.should == "Expected JSON value type to be Numeric, got String"
+    expect(matcher.failure_message_for_should).to eq("Expected JSON value type to be Numeric, got String")
   end
 
   it "provides a failure message for should not" do
     matcher = have_json_type(Numeric)
     matcher.matches?(%(10))
-    matcher.failure_message_for_should_not.should == "Expected JSON value type to not be Numeric, got Fixnum"
+    expect(matcher.failure_message_for_should_not).to eq("Expected JSON value type to not be Numeric, got Fixnum")
   end
 
   it "provides a description message" do
     matcher = have_json_type(String)
     matcher.matches?(%({"id":1,"json":"spec"}))
-    matcher.description.should == %(have JSON type "String")
+    expect(matcher.description).to eq(%(have JSON type "String"))
   end
 
   it "provides a description message with path" do
     matcher = have_json_type(String).at_path("json")
     matcher.matches?(%({"id":1,"json":"spec"}))
-    matcher.description.should == %(have JSON type "String" at path "json")
+    expect(matcher.description).to eq(%(have JSON type "String" at path "json"))
   end
 
   context "somewhat uselessly" do
     it "matches true" do
-      %(true).should have_json_type(TrueClass)
+      expect(%(true)).to have_json_type(TrueClass)
     end
 
     it "matches false" do
-      %(false).should have_json_type(FalseClass)
+      expect(%(false)).to have_json_type(FalseClass)
     end
 
     it "matches null" do
       null = %(null)
-      null.should have_json_type(NilClass)
-      null.should have_json_type(:nil)
-      null.should have_json_type(:null)
+      expect(null).to have_json_type(NilClass)
+      expect(null).to have_json_type(:nil)
+      expect(null).to have_json_type(:null)
     end
   end
 end

--- a/spec/json_spec/matchers/include_json_spec.rb
+++ b/spec/json_spec/matchers/include_json_spec.rb
@@ -3,80 +3,80 @@ require "spec_helper"
 describe JsonSpec::Matchers::IncludeJson do
   it "matches included array elements" do
     json = %(["one",1,1.0,true,false,null])
-    json.should include_json(%("one"))
-    json.should include_json(%(1))
-    json.should include_json(%(1.0))
-    json.should include_json(%(true))
-    json.should include_json(%(false))
-    json.should include_json(%(null))
+    expect(json).to include_json(%("one"))
+    expect(json).to include_json(%(1))
+    expect(json).to include_json(%(1.0))
+    expect(json).to include_json(%(true))
+    expect(json).to include_json(%(false))
+    expect(json).to include_json(%(null))
   end
 
   it "matches an array included in an array" do
     json = %([[1,2,3],[4,5,6]])
-    json.should include_json(%([1,2,3]))
-    json.should include_json(%([4,5,6]))
+    expect(json).to include_json(%([1,2,3]))
+    expect(json).to include_json(%([4,5,6]))
   end
 
   it "matches a hash included in an array" do
     json = %([{"one":1},{"two":2}])
-    json.should include_json(%({"one":1}))
-    json.should include_json(%({"two":2}))
+    expect(json).to include_json(%({"one":1}))
+    expect(json).to include_json(%({"two":2}))
   end
 
   it "matches included hash values" do
     json = %({"string":"one","integer":1,"float":1.0,"true":true,"false":false,"null":null})
-    json.should include_json(%("one"))
-    json.should include_json(%(1))
-    json.should include_json(%(1.0))
-    json.should include_json(%(true))
-    json.should include_json(%(false))
-    json.should include_json(%(null))
+    expect(json).to include_json(%("one"))
+    expect(json).to include_json(%(1))
+    expect(json).to include_json(%(1.0))
+    expect(json).to include_json(%(true))
+    expect(json).to include_json(%(false))
+    expect(json).to include_json(%(null))
   end
 
   it "matches a hash included in a hash" do
     json = %({"one":{"two":3},"four":{"five":6}})
-    json.should include_json(%({"two":3}))
-    json.should include_json(%({"five":6}))
+    expect(json).to include_json(%({"two":3}))
+    expect(json).to include_json(%({"five":6}))
   end
 
   it "matches an array included in a hash" do
     json = %({"one":[2,3],"four":[5,6]})
-    json.should include_json(%([2,3]))
-    json.should include_json(%([5,6]))
+    expect(json).to include_json(%([2,3]))
+    expect(json).to include_json(%([5,6]))
   end
 
   it "matches a substring" do
     json = %("json")
-    json.should include_json(%("js"))
-    json.should include_json(%("json"))
+    expect(json).to include_json(%("js"))
+    expect(json).to include_json(%("json"))
   end
 
   it "matches at a path" do
-    %({"one":{"two":[3,4]}}).should include_json(%([3,4])).at_path("one")
+    expect(%({"one":{"two":[3,4]}})).to include_json(%([3,4])).at_path("one")
   end
 
   it "ignores excluded keys" do
-    %([{"id":1,"two":3}]).should include_json(%({"two":3}))
+    expect(%([{"id":1,"two":3}])).to include_json(%({"two":3}))
   end
 
   it "provides a description message" do
     matcher = include_json(%({"json":"spec"}))
     matcher.matches?(%({"id":1,"json":"spec"}))
-    matcher.description.should == "include JSON"
+    expect(matcher.description).to eq("include JSON")
   end
 
   it "provides a description message with path" do
     matcher = include_json(%("spec")).at_path("json/0")
     matcher.matches?(%({"id":1,"json":["spec"]}))
-    matcher.description.should == %(include JSON at path "json/0")
+    expect(matcher.description).to eq(%(include JSON at path "json/0"))
   end
 
   it "raises an error when not given expected JSON" do
-    expect{ %([{"id":1,"two":3}]).should include_json }.to raise_error
+    expect{ expect(%([{"id":1,"two":3}])).to include_json }.to raise_error
   end
 
   it "matches file contents" do
     JsonSpec.directory = files_path
-    %({"one":{"value":"from_file"},"four":{"five":6}}).should include_json.from_file("one.json")
+    expect(%({"one":{"value":"from_file"},"four":{"five":6}})).to include_json.from_file("one.json")
   end
 end

--- a/spec/json_spec/matchers_spec.rb
+++ b/spec/json_spec/matchers_spec.rb
@@ -11,25 +11,25 @@ describe JsonSpec::Matchers do
 
   context "be_json_eql" do
     it "instantiates its matcher" do
-      JsonSpec::Matchers::BeJsonEql.should_receive(:new).with(json)
+      expect(JsonSpec::Matchers::BeJsonEql).to receive(:new).with(json)
       environment.be_json_eql(json)
     end
 
     it "returns its matcher" do
       matcher = environment.be_json_eql(json)
-      matcher.should be_a(JsonSpec::Matchers::BeJsonEql)
+      expect(matcher).to be_a(JsonSpec::Matchers::BeJsonEql)
     end
   end
 
   context "include_json" do
     it "instantiates its matcher" do
-      JsonSpec::Matchers::IncludeJson.should_receive(:new).with(json)
+      expect(JsonSpec::Matchers::IncludeJson).to receive(:new).with(json)
       environment.include_json(json)
     end
 
     it "returns its matcher" do
       matcher = environment.include_json(json)
-      matcher.should be_a(JsonSpec::Matchers::IncludeJson)
+      expect(matcher).to be_a(JsonSpec::Matchers::IncludeJson)
     end
   end
 
@@ -37,13 +37,13 @@ describe JsonSpec::Matchers do
     let(:path){ "json" }
 
     it "instantiates its matcher" do
-      JsonSpec::Matchers::HaveJsonPath.should_receive(:new).with(path)
+      expect(JsonSpec::Matchers::HaveJsonPath).to receive(:new).with(path)
       environment.have_json_path(path)
     end
 
     it "returns its matcher" do
       matcher = environment.have_json_path(path)
-      matcher.should be_a(JsonSpec::Matchers::HaveJsonPath)
+      expect(matcher).to be_a(JsonSpec::Matchers::HaveJsonPath)
     end
   end
 
@@ -51,13 +51,13 @@ describe JsonSpec::Matchers do
     let(:type){ Hash }
 
     it "instantiates its matcher" do
-      JsonSpec::Matchers::HaveJsonType.should_receive(:new).with(type)
+      expect(JsonSpec::Matchers::HaveJsonType).to receive(:new).with(type)
       environment.have_json_type(type)
     end
 
     it "returns its matcher" do
       matcher = environment.have_json_type(type)
-      matcher.should be_a(JsonSpec::Matchers::HaveJsonType)
+      expect(matcher).to be_a(JsonSpec::Matchers::HaveJsonType)
     end
   end
 
@@ -65,13 +65,13 @@ describe JsonSpec::Matchers do
     let(:size){ 1 }
 
     it "instantiates its matcher" do
-      JsonSpec::Matchers::HaveJsonSize.should_receive(:new).with(size)
+      expect(JsonSpec::Matchers::HaveJsonSize).to receive(:new).with(size)
       environment.have_json_size(size)
     end
 
     it "returns its matcher" do
       matcher = environment.have_json_size(size)
-      matcher.should be_a(JsonSpec::Matchers::HaveJsonSize)
+      expect(matcher).to be_a(JsonSpec::Matchers::HaveJsonSize)
     end
   end
 end

--- a/spec/json_spec/memory_spec.rb
+++ b/spec/json_spec/memory_spec.rb
@@ -2,31 +2,31 @@ require "spec_helper"
 
 describe JsonSpec::Memory do
   it "has a memory" do
-    JsonSpec.memory.should == {}
+    expect(JsonSpec.memory).to eq({})
   end
 
   it "memorizes strings" do
     JsonSpec.memorize(:key, "value")
-    JsonSpec.memory.should == {:key => "value"}
+    expect(JsonSpec.memory).to eq({:key => "value"})
   end
 
   it "symbolizes keys" do
     JsonSpec.memorize("key", "value")
-    JsonSpec.memory.should == {:key => "value"}
+    expect(JsonSpec.memory).to eq({:key => "value"})
   end
 
   it "regurgitates unremembered strings" do
-    JsonSpec.remember("foo%{bar}").should == "foo%{bar}"
+    expect(JsonSpec.remember("foo%{bar}")).to eq("foo%{bar}")
   end
 
   it "remembers strings" do
     JsonSpec.memorize(:bar, "baz")
-    JsonSpec.remember("foo%{bar}").should == "foobaz"
+    expect(JsonSpec.remember("foo%{bar}")).to eq("foobaz")
   end
 
   it "forgets" do
     JsonSpec.memorize(:key, "value")
     JsonSpec.forget
-    JsonSpec.memory.should == {}
+    expect(JsonSpec.memory).to eq({})
   end
 end


### PR DESCRIPTION
This bumps the RSpec version to 2.14.1 and updates the tests to use the `expect` syntax.  RSpec 3.0 removes the `should` syntax, so this prepares the gem for supporting RSpec 3.0.

The test suite is green using RSpec 2.14.1 and RSpec 3.0.0.beta1.

More information about RSpec 3.0:  http://myronmars.to/n/dev-blog/2013/11/rspec-2-99-and-3-0-betas-have-been-released
