### PR TITLE
Bring back full RSpec runtime dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,5 @@ gemspec
 
 group :test do
   gem "cucumber", "~> 1.1", ">= 1.1.1"
-  gem "rspec", "~> 2.0"
   gem "rake", "~> 10.0"
 end

--- a/json_spec.gemspec
+++ b/json_spec.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |gem|
   gem.license     = "MIT"
 
   gem.add_dependency "multi_json", "~> 1.0"
-  gem.add_dependency "rspec-expectations", ">= 2.0", "< 4.0"
+  gem.add_dependency "rspec", ">= 2.0", "< 4.0"
 
   gem.add_development_dependency "bundler", "~> 1.0"
 


### PR DESCRIPTION
Fixup for 8fdd8d2b3c725a2156690458ac7dbc36d5cdd94a.

Didn't commit by mistake.  Every project which depends on JsonSpec will
refuse to run specs without that.  How pity that Travis couldn't detect
this problem.
