### PR TITLE
Shortcut syntax idea

### DIFF
--- a/lib/json_spec/matchers.rb
+++ b/lib/json_spec/matchers.rb
@@ -3,6 +3,7 @@ require "json_spec/matchers/include_json"
 require "json_spec/matchers/have_json_path"
 require "json_spec/matchers/have_json_type"
 require "json_spec/matchers/have_json_size"
+require "json_spec/matchers/have"
 
 module JsonSpec
   module Matchers
@@ -24,6 +25,10 @@ module JsonSpec
 
     def have_json_size(size)
       JsonSpec::Matchers::HaveJsonSize.new(size)
+    end
+
+    def have(path, type='')
+      JsonSpec::Matchers::Have.new(path, type)
     end
   end
 end

--- a/lib/json_spec/matchers/have.rb
+++ b/lib/json_spec/matchers/have.rb
@@ -1,0 +1,46 @@
+module JsonSpec
+  module Matchers
+    class Have
+      include JsonSpec::Helpers
+      include JsonSpec::Messages
+
+      def initialize(path, type)
+        @path = path.to_s
+        @class = extract_class(path, type)
+      end
+
+      def matches?(json)
+        begin
+          @value = parse_json(json, @path)
+        rescue JsonSpec::MissingPath
+          false
+        end
+        @value.class <= @class
+      end
+
+      def failure_message_for_should
+        message_with_path("Expected JSON value type to be #{@class}, got #{@value.class}")
+      end
+
+      def failure_message_for_should_not
+        message_with_path("Expected JSON value type to not be #{@class}, got #{@value.class}")
+      end
+
+      def description
+        message_with_path(%(have JSON type "#{@class}"))
+      end
+
+      private
+        def extract_class(path, type)
+          if type.class == String and type.empty?
+            class_name = path.class
+            class_name = Integer if class_name == Symbol
+          else
+            class_name = type
+          end
+
+          class_name
+        end
+    end
+  end
+end

--- a/spec/json_spec/matchers/have_spec.rb
+++ b/spec/json_spec/matchers/have_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+
+describe JsonSpec::Matchers::Have do
+
+  context 'matches by default' do
+    it 'symbol as integer' do
+      %({"one":1}).should have :one
+    end
+
+    it 'string as string' do
+      %({"one":"one"}).should have 'one'
+    end
+  end
+
+  context 'matches defined type' do
+    it 'key as symbol' do
+      %({"one":true}).should have :one, TrueClass
+    end
+    it 'key as string' do
+      %({"one":true}).should have 'one', TrueClass
+    end
+  end
+
+  it 'matches hash keys' do
+    %({"one":{"two":{"three":4}}}).should have 'one/two/three', Integer
+  end
+
+  it "doesn't match values" do
+    %({"one":{"two":{"three":4}}}).should_not have 'one/two/three', String
+  end
+
+  it "provides a description message" do
+    matcher = have 'json'
+    matcher.matches?(%({"id":1,"json":"spec"}))
+    matcher.description.should == %(have JSON type "String" at path "json")
+  end
+
+end


### PR DESCRIPTION
Just an idea and working code.
Added `have` matcher. It accepts path and type. Type is not required.
Symbol will be interpreted as Integer and a string as String
Examples:

``` ruby
json = normalize_json(last_response.body)

# json.should have_json_type(Integer).at_path('id')
# can be written as
json.should have :id
# or
json.should have :id, Integer

# json.should have_json_type(String).at_path('first_name')
json.should have 'first_name'

# any defined class
json.should have :my_float, Float
json.should have 'my/flag', TrueClass
```
