### PR TITLE
Fix uninitialized ivar warning

### DIFF
--- a/lib/json_spec/matchers/be_json_eql.rb
+++ b/lib/json_spec/matchers/be_json_eql.rb
@@ -13,6 +13,7 @@ module JsonSpec
 
       def initialize(expected_json = nil)
         @expected_json = expected_json
+        @path = nil
       end
 
       def matches?(actual_json)


### PR DESCRIPTION
Initialize the `@path` instance variable to fix this warning:

```
be_json_eql.rb:21: warning: instance variable @path not initialized
```
