### PR TITLE
Allow include_json to match against subset hash at current position

### DIFF
--- a/lib/json_spec/matchers/include_json.rb
+++ b/lib/json_spec/matchers/include_json.rb
@@ -15,7 +15,11 @@ module JsonSpec
         actual = parse_json(actual_json, @path)
         expected = exclude_keys(parse_json(@expected_json))
         case actual
-        when Hash then actual.values.map { |v| exclude_keys(v) }.include?(expected)
+        when Hash then
+          if expected.instance_of?(Hash)
+            return true if expected.keys.all?{|key| actual[key] == expected[key]}
+          end
+          actual.values.map { |v| exclude_keys(v) }.include?(expected)
         when Array then actual.map { |e| exclude_keys(e) }.include?(expected)
         when String then actual.include?(expected)
         else false

--- a/spec/json_spec/matchers/include_json_spec.rb
+++ b/spec/json_spec/matchers/include_json_spec.rb
@@ -79,4 +79,10 @@ describe JsonSpec::Matchers::IncludeJson do
     JsonSpec.directory = files_path
     %({"one":{"value":"from_file"},"four":{"five":6}}).should include_json.from_file("one.json")
   end
+
+  it "matches subset hash included in current position" do
+    json = %({"one": 1, "two": 2, "three": {"foo": 1, "bar": 2, "baz": 3}})
+    json.should include_json(%({"one": 1, "two": 2}))
+    json.should include_json(%({"foo": 1, "baz": 3})).at_path("three")
+  end
 end


### PR DESCRIPTION
I wanted to match an expected subset hash against the "current position". The scenario is the following: I have an API and the response should match the specified result. It is ok if there are more attributes, as this does not break the API.

Example in the specs.
