### PR TITLE
return size of 0 if json ruby value is nil

### DIFF
--- a/features/sizes.feature
+++ b/features/sizes.feature
@@ -36,3 +36,21 @@ Feature: Sizes
     Then the JSON at "one" should have 1 entry
     And the JSON at "two" should have 2 values
     And the JSON at "three" should have 3 numbers
+
+
+  Scenario: A null value returned instead of an empty array
+    Given the JSON is:
+    """
+      {
+        "id": null,
+        "array_with_null" : [null],
+        "value_as_null" : null,
+        "non_null_value" : 12345
+      }
+      """
+    When I get the JSON
+    Then the JSON at "array_with_null" should have 1 entry
+    And the JSON at "value_as_null" should not have 1 entry
+
+    And the JSON at "value_as_null" should have 0 entry
+    And the JSON at "non_null_value" should have 1 entry

--- a/lib/json_spec/matchers/have_json_size.rb
+++ b/lib/json_spec/matchers/have_json_size.rb
@@ -10,7 +10,11 @@ module JsonSpec
 
       def matches?(json)
         ruby = parse_json(json, @path)
-        @actual = Enumerable === ruby ? ruby.size : 1
+        if ruby.nil?
+          @actual = 0
+        else
+          @actual = Enumerable === ruby ? ruby.size : 1
+        end
         @actual == @expected
       end
 


### PR DESCRIPTION
An entry can be null such as [null], which is 1 entry. If a null is a value of an Array, then the array has 0 entry.  However a null value returns a size of 1

def matches?(json)
       ruby = parse_json(json, @path)
      #when ruby = nil 
      #NoMethodError: undefined method `size' for nil:NilClass
      # so @actual = 1 when ruby is nil
     @actual = Enumerable === ruby ? ruby.size : 1
      @actual == @expected
  end
