### PR TITLE
Allow matching out-of-order arrays with .in_any_order

### DIFF
--- a/lib/json_spec.rb
+++ b/lib/json_spec.rb
@@ -5,6 +5,7 @@ require "json_spec/configuration"
 require "json_spec/exclusion"
 require "json_spec/helpers"
 require "json_spec/messages"
+require "json_spec/indifference"
 require "json_spec/matchers"
 require "json_spec/memory"
 

--- a/lib/json_spec.rb
+++ b/lib/json_spec.rb
@@ -5,7 +5,7 @@ require "json_spec/configuration"
 require "json_spec/exclusion"
 require "json_spec/helpers"
 require "json_spec/messages"
-require "json_spec/indifference"
+require "json_spec/order_indifference"
 require "json_spec/matchers"
 require "json_spec/memory"
 

--- a/lib/json_spec/indifference.rb
+++ b/lib/json_spec/indifference.rb
@@ -1,0 +1,25 @@
+module JsonSpec
+  module Indifference
+    extend self
+
+    def toggle_indifference( toggle )
+      @indifferent = !!toggle
+    end
+
+    def indifferize(ruby)
+      return ruby unless @indifferent
+
+      case ruby
+      when Hash
+        ruby.sort.inject({}) do |hash, (key, value)|
+          hash[key] = indifferize(value)
+          hash
+        end
+      when Array
+        ruby.map{|v| indifferize(v) }.sort_by{|v| generate_normalized_json(v) }
+      else ruby
+      end
+    end
+
+  end
+end

--- a/lib/json_spec/matchers/be_json_eql.rb
+++ b/lib/json_spec/matchers/be_json_eql.rb
@@ -3,7 +3,7 @@ module JsonSpec
     class BeJsonEql
       include JsonSpec::Helpers
       include JsonSpec::Exclusion
-      include JsonSpec::Indifference
+      include JsonSpec::OrderIndifference
       include JsonSpec::Messages
 
       attr_reader :expected, :actual
@@ -43,8 +43,8 @@ module JsonSpec
         self
       end
 
-      def order_indifferent(state = true)
-        toggle_indifference(state)
+      def in_any_order(state = true)
+        toggle_order_indifference(state)
         self
       end
 

--- a/lib/json_spec/matchers/be_json_eql.rb
+++ b/lib/json_spec/matchers/be_json_eql.rb
@@ -3,6 +3,7 @@ module JsonSpec
     class BeJsonEql
       include JsonSpec::Helpers
       include JsonSpec::Exclusion
+      include JsonSpec::Indifference
       include JsonSpec::Messages
 
       attr_reader :expected, :actual
@@ -42,6 +43,11 @@ module JsonSpec
         self
       end
 
+      def order_indifferent(state = true)
+        toggle_indifference(state)
+        self
+      end
+
       def failure_message
         message_with_path("Expected equivalent JSON")
       end
@@ -58,7 +64,7 @@ module JsonSpec
 
       private
         def scrub(json, path = nil)
-          generate_normalized_json(exclude_keys(parse_json(json, path))).chomp + "\n"
+          generate_normalized_json(indifferize(exclude_keys(parse_json(json, path)))).chomp + "\n"
         end
     end
   end

--- a/lib/json_spec/order_indifference.rb
+++ b/lib/json_spec/order_indifference.rb
@@ -1,8 +1,8 @@
 module JsonSpec
-  module Indifference
+  module OrderIndifference
     extend self
 
-    def toggle_indifference( toggle )
+    def toggle_order_indifference(toggle)
       @indifferent = !!toggle
     end
 
@@ -11,7 +11,7 @@ module JsonSpec
 
       case ruby
       when Hash
-        ruby.sort.inject({}) do |hash, (key, value)|
+        ruby.inject({}) do |hash, (key, value)|
           hash[key] = indifferize(value)
           hash
         end

--- a/spec/json_spec/matchers/be_json_eql_spec.rb
+++ b/spec/json_spec/matchers/be_json_eql_spec.rb
@@ -17,12 +17,28 @@ describe JsonSpec::Matchers::BeJsonEql do
     %(["json","spec"]).should_not be_json_eql(%(["spec","json"]))
   end
 
+  it "matches out-of-order arrays when chained with order_indifferent" do
+    %(["json","spec"]).should be_json_eql(%(["spec","json"])).order_indifferent
+  end
+
+  it "doesn't match out-of-order arrays when chained with order_indifferent if passed false" do
+    %(["json","spec"]).should_not be_json_eql(%(["spec","json"])).order_indifferent(false)
+  end
+
+  it "matches complex nested out-of-order arrays when chained with order_indifferent" do
+    %({"json":[{"spec":4,"laser":[{"id":2,"lemon":"a"},{"id":5,"lemon":"b"}]},{"spec":9,"laser":[{"id":3,"lemon":"c"},{"id":1,"lemon":"d"}]}]}).should be_json_eql(%({"json":[{"laser":[{"lemon":"d","id":1},{"lemon":"c","id":3}],"spec":9},{"laser":[{"lemon":"b","id":5},{"lemon":"a","id":2}],"spec":4}]})).order_indifferent
+  end
+
   it "matches valid JSON values, yet invalid JSON documents" do
     %("json_spec").should be_json_eql(%("json_spec"))
   end
 
   it "matches at a path" do
     %({"json":["spec"]}).should be_json_eql(%("spec")).at_path("json/0")
+  end
+
+  it "matches out-of-order arrays at a path when chained with order_indifferent" do
+    %({"json":[{"spec":[4,2,3,1,5]}]}).should be_json_eql(%([1,2,3,4,5])).at_path("json/0/spec").order_indifferent
   end
 
   it "ignores excluded-by-default hash keys" do
@@ -64,6 +80,11 @@ describe JsonSpec::Matchers::BeJsonEql do
   it "excludes extra hash keys given as symbols" do
     JsonSpec.excluded_keys = []
     %({"id":1,"json":"spec"}).should be_json_eql(%({"id":2,"json":"spec"})).excluding(:id)
+  end
+
+  it "excludes extra hash keys given as symbols and matches out-of-order arrays when chained with order_indifferent" do
+    JsonSpec.excluded_keys = []
+    %([{"id":1,"json":"spec"},{"id":4,"json":"laser"}]).should be_json_eql(%([{"id":3,"json":"laser"},{"id":2,"json":"spec"}])).excluding(:id).order_indifferent
   end
 
   it "excludes multiple keys" do

--- a/spec/json_spec/matchers/be_json_eql_spec.rb
+++ b/spec/json_spec/matchers/be_json_eql_spec.rb
@@ -17,16 +17,20 @@ describe JsonSpec::Matchers::BeJsonEql do
     %(["json","spec"]).should_not be_json_eql(%(["spec","json"]))
   end
 
-  it "matches out-of-order arrays when chained with order_indifferent" do
-    %(["json","spec"]).should be_json_eql(%(["spec","json"])).order_indifferent
+  it "matches out-of-order arrays when chained with in_any_order" do
+    %(["json","spec"]).should be_json_eql(%(["spec","json"])).in_any_order
   end
 
-  it "doesn't match out-of-order arrays when chained with order_indifferent if passed false" do
-    %(["json","spec"]).should_not be_json_eql(%(["spec","json"])).order_indifferent(false)
+  it "matches out-of-order hashes when chained with in_any_order" do
+    %({"laser":"lemon","json":"spec"}).should be_json_eql(%({"json":"spec","laser":"lemon"})).in_any_order
   end
 
-  it "matches complex nested out-of-order arrays when chained with order_indifferent" do
-    %({"json":[{"spec":4,"laser":[{"id":2,"lemon":"a"},{"id":5,"lemon":"b"}]},{"spec":9,"laser":[{"id":3,"lemon":"c"},{"id":1,"lemon":"d"}]}]}).should be_json_eql(%({"json":[{"laser":[{"lemon":"d","id":1},{"lemon":"c","id":3}],"spec":9},{"laser":[{"lemon":"b","id":5},{"lemon":"a","id":2}],"spec":4}]})).order_indifferent
+  it "doesn't match out-of-order arrays when chained with in_any_order if passed false" do
+    %(["json","spec"]).should_not be_json_eql(%(["spec","json"])).in_any_order(false)
+  end
+
+  it "matches complex nested out-of-order arrays when chained with in_any_order" do
+    %({"json":[{"spec":4,"laser":[{"id":2,"lemon":"a"},{"id":5,"lemon":"b"}]},{"spec":9,"laser":[{"id":3,"lemon":"c"},{"id":1,"lemon":"d"}]}]}).should be_json_eql(%({"json":[{"laser":[{"lemon":"d","id":1},{"lemon":"c","id":3}],"spec":9},{"laser":[{"lemon":"b","id":5},{"lemon":"a","id":2}],"spec":4}]})).in_any_order
   end
 
   it "matches valid JSON values, yet invalid JSON documents" do
@@ -37,8 +41,8 @@ describe JsonSpec::Matchers::BeJsonEql do
     %({"json":["spec"]}).should be_json_eql(%("spec")).at_path("json/0")
   end
 
-  it "matches out-of-order arrays at a path when chained with order_indifferent" do
-    %({"json":[{"spec":[4,2,3,1,5]}]}).should be_json_eql(%([1,2,3,4,5])).at_path("json/0/spec").order_indifferent
+  it "matches out-of-order arrays at a path when chained with in_any_order" do
+    %({"json":[{"spec":[4,2,3,1,5]}]}).should be_json_eql(%([1,2,3,4,5])).at_path("json/0/spec").in_any_order
   end
 
   it "ignores excluded-by-default hash keys" do
@@ -82,9 +86,9 @@ describe JsonSpec::Matchers::BeJsonEql do
     %({"id":1,"json":"spec"}).should be_json_eql(%({"id":2,"json":"spec"})).excluding(:id)
   end
 
-  it "excludes extra hash keys given as symbols and matches out-of-order arrays when chained with order_indifferent" do
+  it "excludes extra hash keys given as symbols and matches out-of-order arrays when chained with in_any_order" do
     JsonSpec.excluded_keys = []
-    %([{"id":1,"json":"spec"},{"id":4,"json":"laser"}]).should be_json_eql(%([{"id":3,"json":"laser"},{"id":2,"json":"spec"}])).excluding(:id).order_indifferent
+    %([{"id":1,"json":"spec"},{"id":4,"json":"laser"}]).should be_json_eql(%([{"id":3,"json":"laser"},{"id":2,"json":"spec"}])).excluding(:id).in_any_order
   end
 
   it "excludes multiple keys" do


### PR DESCRIPTION
My team needed a way to reliably, consistently test the JSON returned by our API, despite the facts that:
- the controller that builds the JSON might retrieve models in _any_ order (not deterministic), and
- the client that will consume the JSON does not care about the order of models in the array.

For example, our API might respond with `{"objects":[{"id":1,"some_attribute":"foo"},{"id":2,"some_attribute":"bar"}]}` and that would be totally valid, but it is just as likely to respond with `{"objects":[{"id":2,"some_attribute":"bar"},{"id":1,"some_attribute":"foo"}]}` instead, and that should also be valid.

To allow the `be_json_eql` matcher to match out-of-order arrays, I've added the chain method `.in_any_order`. It works by sorting each array in lexical order according to the JSON string representation of the element.

You can also pass `false` to `.in_any_order` if you want to, which then behaves as if you had not chained `.in_any_order` at all (in case someone needs to determine indifference dynamically at runtime).

Examples are available in the modified `be_json_eql_spec.rb` file. I also added some tests to ensure that this feature should work correctly when combined with the other features of this matcher.
