### PR TITLE
Validate that the input to remember will not try to use the numeric %

### DIFF
--- a/lib/json_spec/memory.rb
+++ b/lib/json_spec/memory.rb
@@ -9,7 +9,7 @@ module JsonSpec
     end
 
     def remember(json)
-      memory.empty? ? json : json % memory
+      (memory.empty? or json.is_a?(Numeric)) ? json : json % memory
     end
 
     def forget

--- a/spec/json_spec/memory_spec.rb
+++ b/spec/json_spec/memory_spec.rb
@@ -24,6 +24,11 @@ describe JsonSpec::Memory do
     JsonSpec.remember("foo%{bar}").should == "foobaz"
   end
 
+  it "ignores numeric types" do
+    JsonSpec.memorize(:bar, "baz")
+    JsonSpec.remember(10).should == 10
+  end
+
   it "forgets" do
     JsonSpec.memorize(:key, "value")
     JsonSpec.forget


### PR DESCRIPTION
The code in JsonSpec.remember assumes that the incoming argument will
be a string and uses the % operator to interpolate from the memory
hash into the string.  However, it is perfectly possible to pass in a
Numeric type (e.g. Fixnum) for which the % operator means something
totally different which causes the code to try to convert the hash to
fixnum, which it can't.

Fixes #90