### PR TITLE
Allow to memorize parsed values

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,37 @@ You can also remember JSON inline:
 Then the JSON response at "0/first_name" should be %{FIRST_NAME}
 ```
 
+If the value should be parsed before memorizing, "parsed" modifier can be used.
+For example:
+
+Response data:
+```json
+[
+  {
+    "uuid": "ad796a4b",
+    "url": "/entities/ad796a4b"
+  }
+]
+```
+
+```cucumber
+Given I keep the JSON at "0/uuid" as parsed "UUID"
+```
+
+Now `%{UUID}` will be replaced with `ad796a4b` instead of `"ad796a4b"`, so it can be interpolated into the string:
+
+```cucumber
+Then the JSON should be:
+"""
+[
+  {
+    "uuid": "%{UUID}",
+    "url": "/entities/%{UUID}"
+  }
+]
+"""
+```
+
 ### More
 
 Check out the [specs](https://github.com/collectiveidea/json_spec/blob/master/spec)

--- a/features/memory.feature
+++ b/features/memory.feature
@@ -183,6 +183,26 @@ Feature: Memory
       }
       """
 
+  Scenario: Parsed value
+    Given the JSON is:
+      """
+      {
+        "uuid": "ad796a4b",
+        "url": "/entities/ad796a4b"
+      }
+      """
+    And I get the JSON
+
+    When I keep the JSON at "uuid" as parsed "UUID"
+    Then the JSON at "uuid" should be "%{UUID}"
+    And the JSON should be:
+    """
+    {
+      "uuid": "%{UUID}",
+      "url": "/entities/%{UUID}"
+    }
+    """
+
   Scenario: Table format
     When I keep the JSON at "string" as "STRING"
     And I keep the JSON at "integer" as "INTEGER"

--- a/lib/json_spec/cucumber.rb
+++ b/lib/json_spec/cucumber.rb
@@ -6,8 +6,11 @@ After do
   JsonSpec.forget
 end
 
-When /^(?:I )?keep the (?:JSON|json)(?: response)?(?: at "(.*)")? as "(.*)"$/ do |path, key|
-  JsonSpec.memorize(key, normalize_json(last_json, path))
+When /^(?:I )?keep the (?:JSON|json)(?: response)?(?: at "(.*)")? as( parsed)? "(.*)"$/ do |path, parsed, key|
+  json = normalize_json(last_json, path)
+  json = parse_json(json) if parsed
+
+  JsonSpec.memorize(key, json)
 end
 
 Then /^the (?:JSON|json)(?: response)?(?: at "(.*)")? should( not)? be:$/ do |path, negative, json|


### PR DESCRIPTION
Solves this [#51] issue

## Test from updated README

If the value should be parsed before memorizing, "parsed" modifier can be used.
For example:

Response data:
```json
[
  {
    "uuid": "ad796a4b",
    "url": "/entities/ad796a4b"
  }
]
```

```cucumber
Given I keep the JSON at "0/uuid" as parsed "UUID"
```

Now `%{UUID}` will be replaced with `ad796a4b` instead of `"ad796a4b"`, so it can be interpolated into the string:

```cucumber
Then the JSON should be:
"""
[
  {
    "uuid": "%{UUID}",
    "url": "/entities/%{UUID}"
  }
]
"""
```