### PR TITLE
Fix assorted RSpec warnings when running rspec spec --warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased (master)
 
 - Added Changelog
+- Fix RSpec warnings for uninitialized instance variables on matchers [#78](https://github.com/collectiveidea/json_spec/pull/78)
 
 ## Version 1.1.4
 

--- a/lib/json_spec/configuration.rb
+++ b/lib/json_spec/configuration.rb
@@ -4,6 +4,8 @@ module JsonSpec
   module Configuration
     DEFAULT_EXCLUDED_KEYS = %w(id created_at updated_at)
 
+    attr_accessor :directory
+
     def configure(&block)
       instance_eval(&block)
     end
@@ -20,13 +22,6 @@ module JsonSpec
       self.excluded_keys = keys
     end
 
-    def directory
-      @directory
-    end
-
-    def directory=(directory)
-      @directory = directory
-    end
 
     def reset
       instance_variables.each { |ivar| remove_instance_variable(ivar) }

--- a/lib/json_spec/matchers/be_json_eql.rb
+++ b/lib/json_spec/matchers/be_json_eql.rb
@@ -13,6 +13,7 @@ module JsonSpec
 
       def initialize(expected_json = nil)
         @expected_json = expected_json
+        @path = nil
       end
 
       def matches?(actual_json)

--- a/lib/json_spec/matchers/have_json_size.rb
+++ b/lib/json_spec/matchers/have_json_size.rb
@@ -6,6 +6,7 @@ module JsonSpec
 
       def initialize(size)
         @expected = size
+        @path = nil
       end
 
       def matches?(json)

--- a/lib/json_spec/matchers/have_json_type.rb
+++ b/lib/json_spec/matchers/have_json_type.rb
@@ -6,6 +6,7 @@ module JsonSpec
 
       def initialize(type)
         @classes = type_to_classes(type)
+        @path = nil
       end
 
       def matches?(json)

--- a/lib/json_spec/matchers/include_json.rb
+++ b/lib/json_spec/matchers/include_json.rb
@@ -7,6 +7,7 @@ module JsonSpec
 
       def initialize(expected_json = nil)
         @expected_json = expected_json
+        @path = nil
       end
 
       def matches?(actual_json)

--- a/spec/json_spec/configuration_spec.rb
+++ b/spec/json_spec/configuration_spec.rb
@@ -2,52 +2,52 @@ require "spec_helper"
 
 describe JsonSpec::Configuration do
   it "excludes id and timestamps by default" do
-    JsonSpec.excluded_keys.should == ["id", "created_at", "updated_at"]
+    JsonSpec.excluded_keys.should eq ["id", "created_at", "updated_at"]
   end
 
   it "excludes custom keys" do
     JsonSpec.exclude_keys("token")
-    JsonSpec.excluded_keys.should == ["token"]
+    JsonSpec.excluded_keys.should eq ["token"]
   end
 
   it "excludes custom keys via setter" do
     JsonSpec.excluded_keys = ["token"]
-    JsonSpec.excluded_keys.should == ["token"]
+    JsonSpec.excluded_keys.should eq ["token"]
   end
 
   it "excludes custom keys via block" do
     JsonSpec.configure { |c| c.exclude_keys("token") }
-    JsonSpec.excluded_keys.should == ["token"]
+    JsonSpec.excluded_keys.should eq ["token"]
   end
 
   it "excludes custom keys via block setter" do
     JsonSpec.configure { |c| c.excluded_keys = ["token"] }
-    JsonSpec.excluded_keys.should == ["token"]
+    JsonSpec.excluded_keys.should eq ["token"]
   end
 
   it "excludes custom keys via instance-evaluated block" do
     JsonSpec.configure{ exclude_keys("token") }
-    JsonSpec.excluded_keys.should == ["token"]
+    JsonSpec.excluded_keys.should eq ["token"]
   end
 
   it "ensures its excluded keys are strings" do
     JsonSpec.exclude_keys(:token)
-    JsonSpec.excluded_keys.should == ["token"]
+    JsonSpec.excluded_keys.should eq ["token"]
   end
 
   it "ensures its excluded keys are unique" do
     JsonSpec.exclude_keys("token", :token)
-    JsonSpec.excluded_keys.should == ["token"]
+    JsonSpec.excluded_keys.should eq ["token"]
   end
 
   it "resets its excluded keys" do
     original = JsonSpec.excluded_keys
 
     JsonSpec.exclude_keys("token")
-    JsonSpec.excluded_keys.should_not == original
+    JsonSpec.excluded_keys.should_not eq original
 
     JsonSpec.reset
-    JsonSpec.excluded_keys.should == original
+    JsonSpec.excluded_keys.should eq original
   end
 
   it "resets its directory" do

--- a/spec/json_spec/helpers_spec.rb
+++ b/spec/json_spec/helpers_spec.rb
@@ -5,11 +5,11 @@ describe JsonSpec::Helpers do
 
   context "parse_json" do
     it "parses JSON documents" do
-      parse_json(%({"json":["spec"]})).should == {"json" => ["spec"]}
+      parse_json(%({"json":["spec"]})).should eq({"json" => ["spec"]})
     end
 
     it "parses JSON values" do
-      parse_json(%("json_spec")).should == "json_spec"
+      parse_json(%("json_spec")).should eq "json_spec"
     end
 
     it "raises a parser error for invalid JSON" do
@@ -18,8 +18,8 @@ describe JsonSpec::Helpers do
 
     it "parses at a path if given" do
       json = %({"json":["spec"]})
-      parse_json(json, "json").should == ["spec"]
-      parse_json(json, "json/0").should == "spec"
+      parse_json(json, "json").should eq ["spec"]
+      parse_json(json, "json/0").should eq "spec"
     end
 
     it "raises an error for a missing path" do
@@ -31,7 +31,7 @@ describe JsonSpec::Helpers do
 
     it "parses at a numeric string path" do
       json = %({"1":"two"})
-      parse_json(%({"1":"two"}), "1").should == "two"
+      parse_json(json, "1").should eq "two"
     end
   end
 
@@ -44,19 +44,19 @@ describe JsonSpec::Helpers do
   ]
 }
       JSON
-      normalize_json(%({"json":["spec"]})).should == normalized.chomp
+      normalize_json(%({"json":["spec"]})).should eq normalized.chomp
     end
 
     it "normalizes at a path" do
-      normalize_json(%({"json":["spec"]}), "json/0").should == %("spec")
+      normalize_json(%({"json":["spec"]}), "json/0").should eq %("spec")
     end
 
     it "accepts a JSON value" do
-      normalize_json(%("json_spec")).should == %("json_spec")
+      normalize_json(%("json_spec")).should eq %("json_spec")
     end
 
     it "normalizes JSON values" do
-      normalize_json(%(1e+1)).should == %(10.0)
+      normalize_json(%(1e+1)).should eq %(10.0)
     end
   end
 
@@ -69,11 +69,11 @@ describe JsonSpec::Helpers do
   ]
 }
       JSON
-      generate_normalized_json({"json" => ["spec"]}).should == normalized.chomp
+      generate_normalized_json({"json" => ["spec"]}).should eq normalized.chomp
     end
 
     it "generates a normalized JSON value" do
-      generate_normalized_json(nil).should == %(null)
+      generate_normalized_json(nil).should eq %(null)
     end
   end
 
@@ -84,12 +84,12 @@ describe JsonSpec::Helpers do
 
     it "returns JSON when the file exists" do
       JsonSpec.directory = files_path
-      load_json("one.json").should == %({"value":"from_file"})
+      load_json("one.json").should eq %({"value":"from_file"})
     end
 
     it "ignores extra slashes" do
       JsonSpec.directory = "/#{files_path}/"
-      load_json("one.json").should == %({"value":"from_file"})
+      load_json("one.json").should eq %({"value":"from_file"})
     end
 
     it "raises an error when the file doesn't exist" do
@@ -104,8 +104,8 @@ describe JsonSpec::Helpers do
 
     it "finds nested files" do
       JsonSpec.directory = files_path
-      load_json("project/one.json").should == %({"nested":"inside_folder"})
-      load_json("project/version/one.json").should == %({"nested":"deeply"})
+      load_json("project/one.json").should eq %({"nested":"inside_folder"})
+      load_json("project/version/one.json").should eq %({"nested":"deeply"})
     end
   end
 end

--- a/spec/json_spec/matchers/be_json_eql_spec.rb
+++ b/spec/json_spec/matchers/be_json_eql_spec.rb
@@ -99,7 +99,9 @@ describe JsonSpec::Matchers::BeJsonEql do
   end
 
   it "raises an error when not given expected JSON" do
-    expect{ %({"id":1,"json":"spec"}).should be_json_eql }.to raise_error
+    expect{ %({"id":1,"json":"spec"}).should be_json_eql }.to raise_error do |error|
+      error.message.should == "Expected equivalent JSON not provided"
+    end
   end
 
   it "matches file contents" do

--- a/spec/json_spec/matchers/have_json_size_spec.rb
+++ b/spec/json_spec/matchers/have_json_size_spec.rb
@@ -24,27 +24,27 @@ describe JsonSpec::Matchers::HaveJsonSize do
   it "provides a failure message" do
     matcher = have_json_size(3)
     matcher.matches?(%([1,2]))
-    matcher.failure_message.should            == "Expected JSON value size to be 3, got 2"
-    matcher.failure_message_for_should.should == "Expected JSON value size to be 3, got 2" # RSpec 2 interface
+    matcher.failure_message.should            eq "Expected JSON value size to be 3, got 2"
+    matcher.failure_message_for_should.should eq "Expected JSON value size to be 3, got 2" # RSpec 2 interface
   end
 
   it "provides a failure message for negation" do
     matcher = have_json_size(3)
     matcher.matches?(%([1,2,3]))
-    matcher.failure_message_when_negated.should   == "Expected JSON value size to not be 3, got 3"
-    matcher.failure_message_for_should_not.should == "Expected JSON value size to not be 3, got 3" # RSpec 2 interface
+    matcher.failure_message_when_negated.should   eq "Expected JSON value size to not be 3, got 3"
+    matcher.failure_message_for_should_not.should eq "Expected JSON value size to not be 3, got 3" # RSpec 2 interface
   end
 
   it "provides a description message" do
     matcher = have_json_size(1)
     matcher.matches?(%({"id":1,"json":["spec"]}))
-    matcher.description.should == %(have JSON size "1")
+    matcher.description.should eq %(have JSON size "1")
   end
 
   it "provides a description message with path" do
     matcher = have_json_size(1).at_path("json")
     matcher.matches?(%({"id":1,"json":["spec"]}))
-    matcher.description.should == %(have JSON size "1" at path "json")
+    matcher.description.should eq %(have JSON size "1" at path "json")
   end
 
   it "provides an error when parsing nil" do

--- a/spec/json_spec/matchers/have_json_type_spec.rb
+++ b/spec/json_spec/matchers/have_json_type_spec.rb
@@ -49,27 +49,27 @@ describe JsonSpec::Matchers::HaveJsonType do
   it "provides a failure message" do
     matcher = have_json_type(Numeric)
     matcher.matches?(%("foo"))
-    matcher.failure_message.should            == "Expected JSON value type to be Numeric, got String"
-    matcher.failure_message_for_should.should == "Expected JSON value type to be Numeric, got String" # RSpec 2 interface
+    matcher.failure_message.should            eq "Expected JSON value type to be Numeric, got String"
+    matcher.failure_message_for_should.should eq "Expected JSON value type to be Numeric, got String" # RSpec 2 interface
   end
 
   it "provides a failure message for negation" do
     matcher = have_json_type(Numeric)
     matcher.matches?(%(10))
-    matcher.failure_message_when_negated.should   == "Expected JSON value type to not be Numeric, got Fixnum"
-    matcher.failure_message_for_should_not.should == "Expected JSON value type to not be Numeric, got Fixnum" # RSpec 2 interface
+    matcher.failure_message_when_negated.should   eq "Expected JSON value type to not be Numeric, got Fixnum"
+    matcher.failure_message_for_should_not.should eq "Expected JSON value type to not be Numeric, got Fixnum" # RSpec 2 interface
   end
 
   it "provides a description message" do
     matcher = have_json_type(String)
     matcher.matches?(%({"id":1,"json":"spec"}))
-    matcher.description.should == %(have JSON type "String")
+    matcher.description.should eq %(have JSON type "String")
   end
 
   it "provides a description message with path" do
     matcher = have_json_type(String).at_path("json")
     matcher.matches?(%({"id":1,"json":"spec"}))
-    matcher.description.should == %(have JSON type "String" at path "json")
+    matcher.description.should eq %(have JSON type "String" at path "json")
   end
 
   context "somewhat uselessly" do

--- a/spec/json_spec/matchers/include_json_spec.rb
+++ b/spec/json_spec/matchers/include_json_spec.rb
@@ -84,7 +84,9 @@ describe JsonSpec::Matchers::IncludeJson do
   end
 
   it "raises an error when not given expected JSON" do
-    expect{ %([{"id":1,"two":3}]).should include_json }.to raise_error
+    expect{ %([{"id":1,"two":3}]).should include_json }.to raise_error do |error|
+      error.message.should == "Expected included JSON not provided"
+    end
   end
 
   it "matches file contents" do


### PR DESCRIPTION
- Initialize instance variables such as `@path`
- Use `attr_accessor` for simple accessors
- Use `eq` instead of `==` in expectations

Closes #77. Fixes #78.