### PR TITLE
Drop support for Ruby 1.9.3, deprecate 2.0, add 2.2 and 2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,10 @@ language: ruby
 matrix:
   allow_failures:
     - rvm: ruby-head
+    - rvm: "2.0"
 rvm:
-  - 1.9.3
   - "2.0"
   - "2.1"
+  - "2.2"
+  - "2.3.4"
   - ruby-head


### PR DESCRIPTION
No code changes on master, but running travis today we can't install
json_spec on Ruby 1.9.3. Since Ruby 1.9.3 has reached EOL, we're going
to drop support for it.