### PR TITLE
Check for warnings by default rake spec run

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,9 @@ require "bundler/gem_tasks"
 require "rspec/core/rake_task"
 require "cucumber/rake/task"
 
-RSpec::Core::RakeTask.new(:spec)
+RSpec::Core::RakeTask.new(:spec) do |task|
+  task.rspec_opts = "--warnings"
+end
 
 Cucumber::Rake::Task.new(:cucumber) do |task|
   task.cucumber_opts = "--tags ~@fail"


### PR DESCRIPTION
Adds warning checks in the default `rake spec` task.