### PR TITLE
CodeClimate gem, spec_helper note, and Travis hook

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+after_success:
+  - bundle exec codeclimate-test-reporter
 branches:
   only:
     - master

--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,6 @@ source "https://rubygems.org"
 gemspec
 
 group :test do
+  gem "codeclimate-test-reporter", require: false
   gem "cucumber", "~> 1.3"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,6 @@ source "https://rubygems.org"
 gemspec
 
 group :test do
+  gem "codeclimate-test-reporter", "~> 1.0.0"
   gem "cucumber", "~> 1.3"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,5 @@ source "https://rubygems.org"
 gemspec
 
 group :test do
-  gem "codeclimate-test-reporter", require: false
   gem "cucumber", "~> 1.3"
 end

--- a/gemfiles/rspec2.gemfile
+++ b/gemfiles/rspec2.gemfile
@@ -5,6 +5,6 @@ gemspec path: ".."
 gem "rspec", "~> 2.0"
 
 group :test do
-  gem "codeclimate-test-reporter", require: false
+  gem "codeclimate-test-reporter", "~> 1.0.0"
   gem "cucumber", "~> 1.3"
 end

--- a/gemfiles/rspec2.gemfile
+++ b/gemfiles/rspec2.gemfile
@@ -5,5 +5,6 @@ gemspec path: ".."
 gem "rspec", "~> 2.0"
 
 group :test do
+  gem "codeclimate-test-reporter", require: false
   gem "cucumber", "~> 1.3"
 end

--- a/gemfiles/rspec3.gemfile
+++ b/gemfiles/rspec3.gemfile
@@ -5,6 +5,6 @@ gemspec path: ".."
 gem "rspec", "~> 3.0"
 
 group :test do
-  gem "codeclimate-test-reporter", require: false
+  gem "codeclimate-test-reporter", "~> 1.0.0"
   gem "cucumber", "~> 1.3"
 end

--- a/gemfiles/rspec3.gemfile
+++ b/gemfiles/rspec3.gemfile
@@ -5,5 +5,6 @@ gemspec path: ".."
 gem "rspec", "~> 3.0"
 
 group :test do
+  gem "codeclimate-test-reporter", require: false
   gem "cucumber", "~> 1.3"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,8 @@
+if ENV["CODECLIMATE_REPO_TOKEN"]
+  require "simplecov"
+  SimpleCov.start
+end
+
 require "json_spec"
 
 RSpec.configure do |config|


### PR DESCRIPTION
This PR adds a CodeClimate `spec_helper.rb` start instruction, and the reporter gem to the CI gemfiles.

  - ~all it needs is a CODECLIMATE_REPO_TOKEN~ _Fixed_

This is the output after a successful job:

```
$ bundle exec codeclimate-test-reporter
Cannot post results: environment variable CODECLIMATE_REPO_TOKEN must be set.
```