### PR TITLE
Support Ruby 2.4.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,11 @@ matrix:
   allow_failures:
     - rvm: ruby-head
     - rvm: "2.0"
+    - rvm: "2.1"
 rvm:
   - "2.0"
   - "2.1"
-  - "2.2"
+  - "2.2.7"
   - "2.3.4"
+  - "2.4.1"
   - ruby-head

--- a/spec/json_spec/matchers/have_json_type_spec.rb
+++ b/spec/json_spec/matchers/have_json_type_spec.rb
@@ -55,9 +55,10 @@ describe JsonSpec::Matchers::HaveJsonType do
 
   it "provides a failure message for negation" do
     matcher = have_json_type(Numeric)
-    matcher.matches?(%(10))
-    matcher.failure_message_when_negated.should   eq "Expected JSON value type to not be Numeric, got Fixnum"
-    matcher.failure_message_for_should_not.should eq "Expected JSON value type to not be Numeric, got Fixnum" # RSpec 2 interface
+    matcher.matches?(%(10.0))
+
+    matcher.failure_message_when_negated.should   eq "Expected JSON value type to not be Numeric, got Float"
+    matcher.failure_message_for_should_not.should eq "Expected JSON value type to not be Numeric, got Float" # RSpec 2 interface
   end
 
   it "provides a description message" do


### PR DESCRIPTION
This PR **adds Ruby 2.4.1** to the Travis CI matrix.

To pass tests on 2.4, it avoids the Fixnum class.

Also: all EOL'd Ruby versions are now in the `allow_failures` list. [Blog post on 2.1 being EOL](https://www.ruby-lang.org/en/news/2017/04/01/support-of-ruby-2-1-has-ended/).