### PR TITLE
Update cucumber.rb

### DIFF
--- a/lib/json_spec/cucumber.rb
+++ b/lib/json_spec/cucumber.rb
@@ -26,7 +26,7 @@ Then /^the (?:JSON|json)(?: response)?(?: at "(.*)")? should( not)? be file "(.+
   end
 end
 
-Then /^the (?:JSON|json)(?: response)?(?: at "(.*)")? should( not)? be (".*"|\-?\d+(?:\.\d+)?(?:[eE][\+\-]?\d+)?|\[.*\]|%?\{.*\}|true|false|null)$/ do |path, negative, value|
+Then /^the (?:JSON|json)(?: response)?(?: at "(.*)")? should( not)? be (".*"|<.*>|\-?\d+(?:\.\d+)?(?:[eE][\+\-]?\d+)?|\[.*\]|%?\{.*\}|true|false|null)$/ do |path, negative, value|
   if negative
     last_json.should_not be_json_eql(JsonSpec.remember(value)).at_path(path)
   else
@@ -50,7 +50,7 @@ Then /^the (?:JSON|json)(?: response)?(?: at "(.*)")? should( not)? include file
   end
 end
 
-Then /^the (?:JSON|json)(?: response)?(?: at "(.*)")? should( not)? include (".*"|\-?\d+(?:\.\d+)?(?:[eE][\+\-]?\d+)?|\[.*\]|%?\{.*\}|true|false|null)$/ do |path, negative, value|
+Then /^the (?:JSON|json)(?: response)?(?: at "(.*)")? should( not)? include (".*"|<.*>|\-?\d+(?:\.\d+)?(?:[eE][\+\-]?\d+)?|\[.*\]|%?\{.*\}|true|false|null)$/ do |path, negative, value|
   if negative
     last_json.should_not include_json(JsonSpec.remember(value)).at_path(path)
   else


### PR DESCRIPTION
Hello, I'm requesting this extra regex option get added to cucumber.rb to fix an issue I'm having with Scenario Outlines.

Here is an example:
```
Scenario Outline: Example of scenario outline issue
      Given User makes GET request to "www.give-me-a-json.com/api/json"
      And   User receives 200 response code
      Then  the JSON response at "data/someInteger" should be <integer>
      
      Examples:
      | integer |
      | 5       |
```
^^^ The above will give me an undefined step reference error while conversely.... 
```
Scenario: Example of scenario outline issue
      Given User makes GET request to "www.give-me-a-json.com/api/json"
      And   User receives 200 response code
      Then  the JSON response at "data/someInteger" should be 5
```
This will work fine. Adding <.*> will allow for examples table entries to be read, regardless of quotations. It's also an improvement because if the value passed in by the examples table doesn't follow the regex, then it will throw a runtime error.