### PR TITLE
Make matchers composable

### DIFF
--- a/lib/json_spec/matchers/be_json_eql.rb
+++ b/lib/json_spec/matchers/be_json_eql.rb
@@ -1,6 +1,7 @@
 module JsonSpec
   module Matchers
     class BeJsonEql
+      include RSpec::Matchers::Composable
       include JsonSpec::Helpers
       include JsonSpec::Exclusion
       include JsonSpec::Messages

--- a/lib/json_spec/matchers/have_json_path.rb
+++ b/lib/json_spec/matchers/have_json_path.rb
@@ -1,6 +1,7 @@
 module JsonSpec
   module Matchers
     class HaveJsonPath
+      include RSpec::Matchers::Composable
       include JsonSpec::Helpers
 
       def initialize(path)

--- a/lib/json_spec/matchers/have_json_size.rb
+++ b/lib/json_spec/matchers/have_json_size.rb
@@ -1,6 +1,7 @@
 module JsonSpec
   module Matchers
     class HaveJsonSize
+      include RSpec::Matchers::Composable
       include JsonSpec::Helpers
       include JsonSpec::Messages
 

--- a/lib/json_spec/matchers/have_json_type.rb
+++ b/lib/json_spec/matchers/have_json_type.rb
@@ -1,6 +1,7 @@
 module JsonSpec
   module Matchers
     class HaveJsonType
+      include RSpec::Matchers::Composable
       include JsonSpec::Helpers
       include JsonSpec::Messages
 

--- a/lib/json_spec/matchers/include_json.rb
+++ b/lib/json_spec/matchers/include_json.rb
@@ -1,6 +1,7 @@
 module JsonSpec
   module Matchers
     class IncludeJson
+      include RSpec::Matchers::Composable
       include JsonSpec::Helpers
       include JsonSpec::Exclusion
       include JsonSpec::Messages


### PR DESCRIPTION
In order to be able to combine JSON matchers with other RSpec matchers via `and`/`or` API, I included `RSpec::Matchers::Composable` module as suggested in
https://github.com/rspec/rspec-expectations/blob/master/lib/rspec/matchers.rb#L207-L217